### PR TITLE
Support pods with a non-empty .pod.nodeName by replacing with node affinity

### DIFF
--- a/pkg/aaq-server/handler/handler.go
+++ b/pkg/aaq-server/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"kubevirt.io/application-aware-quota/pkg/client"
 	"kubevirt.io/application-aware-quota/pkg/util"
+	"kubevirt.io/application-aware-quota/pkg/util/patch"
 	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	"net/http"
 )
@@ -66,19 +67,27 @@ func (v Handler) mutatePod() (*admissionv1.AdmissionReview, error) {
 	if err := json.Unmarshal(v.request.Object.Raw, &pod); err != nil {
 		return nil, err
 	}
+
 	schedulingGates := pod.Spec.SchedulingGates
 	if schedulingGates == nil {
 		schedulingGates = []v1.PodSchedulingGate{}
 	}
 	schedulingGates = append(schedulingGates, v1.PodSchedulingGate{Name: util.AAQGate})
 
-	schedulingGatesBytes, err := json.Marshal(schedulingGates)
+	patches := []patch.PatchOperation{
+		{
+			Op:    patch.PatchAddOp,
+			Path:  "/spec/schedulingGates",
+			Value: schedulingGates,
+		},
+	}
+
+	patchBytes, err := patch.GeneratePatchPayload(patches...)
 	if err != nil {
 		return nil, err
 	}
 
-	patch := fmt.Sprintf(`[{"op": "add", "path": "/spec/schedulingGates", "value": %s}]`, string(schedulingGatesBytes))
-	return reviewResponseWithPatch(v.request.UID, true, http.StatusAccepted, allowPodRequest, []byte(patch)), nil
+	return reviewResponseWithPatch(v.request.UID, true, http.StatusAccepted, allowPodRequest, patchBytes), nil
 }
 
 func reviewResponseWithPatch(uid types.UID, allowed bool, httpCode int32,

--- a/pkg/aaq-server/handler/handler_test.go
+++ b/pkg/aaq-server/handler/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"kubevirt.io/application-aware-quota/pkg/client"
 	"kubevirt.io/application-aware-quota/pkg/util"
+	"kubevirt.io/application-aware-quota/pkg/util/patch"
 	"kubevirt.io/application-aware-quota/tests/builders"
 	"net/http"
 )
@@ -192,4 +193,75 @@ var _ = Describe("Test handler of aaq server", func() {
 		Entry(" valid Update should be allowed", admissionv1.Update),
 		Entry(" valid Creation should be allowed", admissionv1.Create),
 	)
+
+	It("pod with a non-empty spec.nodeName set", func() {
+		const nodeName = "test-node"
+
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		}
+
+		podBytes, err := json.Marshal(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		v := Handler{
+			request: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Kind: "Pod",
+				},
+				Object: runtime.RawExtension{
+					Raw:    podBytes,
+					Object: pod,
+				},
+				Operation: admissionv1.Create,
+			},
+		}
+		admissionReview, err := v.Handle()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(admissionReview.Response.Allowed).To(BeTrue())
+
+		var patches []patch.PatchOperation
+		err = json.Unmarshal(admissionReview.Response.Patch, &patches)
+		Expect(err).ToNot(HaveOccurred())
+
+		removeNodeNamePatchFound := false
+		nodeAffinityPatchFound := false
+
+		for _, p := range patches {
+			switch p.Path {
+
+			case "/spec/nodeName":
+				removeNodeNamePatchFound = true
+				Expect(p.Op).To(Equal(patch.PatchReplaceOp), "Patch is expected to replace nodeName with an empty string")
+				Expect(p.Value).To(BeEmpty())
+
+			case "/spec/affinity":
+				nodeAffinityPatchFound = true
+
+				var affinity *v1.Affinity
+				valueBytes, err := json.Marshal(p.Value)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = json.Unmarshal(valueBytes, &affinity)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(ContainElement(
+					v1.NodeSelectorTerm{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "metadata.name",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{pod.Spec.NodeName},
+							},
+						},
+					},
+				),
+				)
+			}
+		}
+
+		Expect(removeNodeNamePatchFound).To(BeTrue(), "Patch to remove nodeName is not found")
+		Expect(nodeAffinityPatchFound).To(BeTrue(), "Patch to add node affinity is not found")
+	})
 })

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -1,0 +1,60 @@
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+const (
+	PatchReplaceOp = "replace"
+	PatchTestOp    = "test"
+	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
+)
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
+}
+
+func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]byte, error) {
+	return GeneratePatchPayload(
+		PatchOperation{
+			Op:    PatchTestOp,
+			Path:  path,
+			Value: oldValue,
+		},
+		PatchOperation{
+			Op:    PatchReplaceOp,
+			Path:  path,
+			Value: newValue,
+		},
+	)
+}
+
+func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
+	var p []PatchOperation
+	err := json.Unmarshal(patch, &p)
+
+	return p, err
+}
+
+func EscapeJSONPointer(ptr string) string {
+	s := strings.ReplaceAll(ptr, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
+}

--- a/tests/e2e_application_aware_resource_quota_test.go
+++ b/tests/e2e_application_aware_resource_quota_test.go
@@ -1364,6 +1364,109 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		}, 2*time.Minute, 1*time.Second).Should(BeNil())
 		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 	})
+
+	It("[Serial] should replace .spec.nodeName with node affinity", Serial, func(ctx context.Context) {
+		By("Counting existing ApplicationAwareResourceQuota")
+		c, err := countApplicationAwareResourceQuota(ctx, f.AaqClient, f.Namespace.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating a ApplicationAwareResourceQuota")
+		quotaName := "test-quota"
+		ApplicationAwareResourceQuota := newTestApplicationAwareResourceQuota(quotaName)
+		ApplicationAwareResourceQuota, err = createApplicationAwareResourceQuota(ctx, f.AaqClient, f.Namespace.Name, ApplicationAwareResourceQuota)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Ensuring Application Aware Resource Quota status is calculated")
+		usedResources := v1.ResourceList{}
+		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
+		err = waitForApplicationAwareResourceQuota(ctx, f.AaqClient, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Choosing a node to target")
+		nodeList, err := f.K8sClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		nodeName := utils.GetSchedulableNode(nodeList)
+		Expect(nodeName).ToNot(BeNil())
+		Expect(*nodeName).ToNot(BeEmpty())
+
+		By("Creating a Pod that doesn't fits quota")
+		podName := "test-pod"
+		requests := v1.ResourceList{}
+		requests[v1.ResourceMemory] = resource.MustParse("600Mi") //quota has only 500Mi
+		pod := newTestPodForQuota(podName, requests, nil)
+		pod.Spec.NodeSelector = nil
+		pod.Spec.NodeName = *nodeName
+		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+
+		Expect(err).ToNot(HaveOccurred())
+		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+
+		By("Update arq to fit pod")
+		Eventually(func() error {
+			currApplicationAwareResourceQuota, err := f.AaqClient.AaqV1alpha1().ApplicationAwareResourceQuotas(f.Namespace.Name).Get(ctx, ApplicationAwareResourceQuota.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			currApplicationAwareResourceQuota.Spec.Hard[v1.ResourceMemory] = resource.MustParse("600Mi")
+			_, err = f.AaqClient.AaqV1alpha1().ApplicationAwareResourceQuotas(f.Namespace.Name).Update(ctx, currApplicationAwareResourceQuota, metav1.UpdateOptions{})
+			return err
+		}, 2*time.Minute, 1*time.Second).Should(BeNil())
+		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+
+		By("Ensuring that the pod has proper node affinity")
+		Eventually(func() error {
+			pod, err = f.K8sClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if pod.Spec.Affinity == nil {
+				return fmt.Errorf("pod affinity is nil")
+			}
+
+			expectedNodeSelectorTerm := v1.NodeSelectorTerm{
+				MatchFields: []v1.NodeSelectorRequirement{
+					{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{*nodeName},
+					},
+				},
+			}
+			nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+
+			found := false
+			for _, nodeSelectorTerm := range nodeSelectorTerms {
+				if apiequality.Semantic.DeepEqual(nodeSelectorTerm, expectedNodeSelectorTerm) {
+					found = true
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("did not found expected node affinity")
+			}
+
+			return nil
+		}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+
+		By("Ensuring the pod landed on the right node")
+		Eventually(func() error {
+			pod, err = f.K8sClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if pod.Status.Phase != v1.PodRunning {
+				return fmt.Errorf("the pod is not running yet, has phase: %s", string(pod.Status.Phase))
+			}
+
+			if pod.Spec.NodeName != *nodeName {
+				return fmt.Errorf("pod had landed on the wrong node. Expected: %s, Actual: %s", *nodeName, pod.Spec.NodeName)
+			}
+
+			return nil
+		}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+	})
 })
 
 var _ = Describe("ApplicationAwareResourceQuota", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Creating pods with both scheduling gates and a non-empty `.spec.nodeName` is forbidden in Kubernetes. This causes an issue since AAQ's webhook adds scheduling gates for certain pods, which might have a non-empty nodeName set. 

With this PR's changes, the pod's `.spec.nodeName` would be dropped and instead a node affinity targeting the same node would be added.

For example, a pod with the following spec:
```yaml
spec:
  nodeName: node01
```

would be changed to:
```yaml
spec:
  # nodeName: node01 --> this field is now dropped
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchFields:
          - key: metadata.name
            operator: In
            values:
            - node01
```

This trick allows AAQ to support pods with a target node set.

**Note to reviewer**:
In the first commit, I've imported kubevirt's patch package to ensure the patching code remains elegant.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support pods with a non-empty .pod.nodeName by replacing with node affinity
```
