### PR TITLE
add the Gate Controller as observer to the namespace-quota mapping

### DIFF
--- a/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
+++ b/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
@@ -478,3 +478,11 @@ func (ctrl *AaqGateController) aaqjqcProcessed(aaqjqc *v1alpha12.AAQJobQueueConf
 	}
 	return true
 }
+
+func (ctrl *AaqGateController) AddMapping(_, namespaceName string) {
+	ctrl.nsQueue.Add(namespaceName)
+}
+
+func (ctrl *AaqGateController) RemoveMapping(_, namespaceName string) {
+	ctrl.nsQueue.Add(namespaceName)
+}

--- a/pkg/aaq-controller/application.go
+++ b/pkg/aaq-controller/application.go
@@ -164,10 +164,13 @@ func Execute() {
 	app.initAaqGateController(stop, clusterQuotaLister, namespaceLister, clusterQuotaMapper)
 	app.initRQController(stop)
 
+	if app.enableClusterQuota {
+		app.clusterQuotaMappingController.GetClusterQuotaMapper().AddListener(app.aaqGateController)
+	}
+
 	app.Run(stop)
 
 	klog.V(2).Infoln("AAQ controller exited")
-
 }
 
 func (mca *AaqControllerApp) leaderProbe(_ *restful.Request, response *restful.Response) {

--- a/tests/e2e_application_aware_cluster_resource_quota.go
+++ b/tests/e2e_application_aware_cluster_resource_quota.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/application-aware-quota/tests/builders"
+	"kubevirt.io/application-aware-quota/tests/framework"
+	"kubevirt.io/application-aware-quota/tests/utils"
+	"time"
+)
+
+var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
+	f := framework.NewFramework("application-aware-applied-cluster-resource-quota")
+	var labelSelector *v12.LabelSelector
+
+	BeforeEach(func() {
+		aaq, err := f.AaqClient.AaqV1alpha1().AAQs().Get(context.Background(), "aaq", v12.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		if !aaq.Spec.Configuration.AllowApplicationAwareClusterResourceQuota {
+			aaq.Spec.Configuration.AllowApplicationAwareClusterResourceQuota = true
+			_, err := f.AaqClient.AaqV1alpha1().AAQs().Update(context.Background(), aaq, v12.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() bool {
+				ready, err := utils.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
+				Expect(err).ToNot(HaveOccurred())
+				return ready
+			}, 1*time.Minute, 1*time.Second).ShouldNot(BeTrue(), "config change should trigger redeployment of the controller")
+			Eventually(func() bool {
+				ready, err := utils.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
+				Expect(err).ToNot(HaveOccurred())
+				return ready
+			}, 10*time.Minute, 1*time.Second).Should(BeTrue(), "aaq-controller should be ready with the new config Eventually")
+
+		}
+		labelSelector = &v12.LabelSelector{
+			MatchLabels: map[string]string{"foo": "foo"},
+		}
+		// Function to add label to a namespace
+		err = utils.AddLabelToNamespace(f.K8sClient, "default", "foo", "foo")
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.AddLabelToNamespace(f.K8sClient, f.Namespace.GetName(), "foo", "foo")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := utils.RemoveLabelFromNamespace(f.K8sClient, "default", "foo")
+		Expect(err).ToNot(HaveOccurred())
+		err = utils.RemoveLabelFromNamespace(f.K8sClient, f.Namespace.GetName(), "foo")
+		Expect(err).ToNot(HaveOccurred())
+
+		acrqs, err := f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().List(context.Background(), v12.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		for _, acrq := range acrqs.Items {
+			err := f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Delete(context.Background(), acrq.Name, v12.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	Context("Making sure AAQ Gate Controller receive events", func() {
+		It("Removing label from a namespace should change the quota-namespace mapping and trigger the gate controller", func(ctx context.Context) {
+			acrq := builders.NewAcrqBuilder().
+				WithName("test-quota").
+				WithLabelSelector(labelSelector).
+				WithScopes([]v1.ResourceQuotaScope{v1.ResourceQuotaScopeNotTerminating}).
+				WithResource(v1.ResourceRequestsMemory, resource.MustParse("1Mi")).Build()
+
+			By("Creating a ApplicationAwareClusterResourceQuota")
+			_, err := utils.CreateApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for the ApplicationAwareClusterResourceQuota to be propagated")
+			expectedRresources := v1.ResourceList{}
+			expectedRresources[v1.ResourceRequestsMemory] = resource.MustParse("0")
+			err = utils.WaitForApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq.Name, expectedRresources)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating a pod that should be Gated")
+			podName := "test-pod"
+			requests := v1.ResourceList{}
+			requests[v1.ResourceMemory] = resource.MustParse("200Mi")
+			pod := utils.NewTestPodForQuota(podName, requests, v1.ResourceList{})
+			_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, v12.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+
+			By("Making sure acrq include both default, test namespaces")
+			Eventually(func() []string {
+				acrq, err = f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Get(ctx, acrq.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				var namespaces []string
+				for _, ns := range acrq.Status.Namespaces {
+					namespaces = append(namespaces, ns.Namespace)
+				}
+				return namespaces
+			}, 10*time.Second, 1*time.Second).Should(ContainElements("default", f.Namespace.Name), "acrq should include both default and test namespaces")
+
+			err = utils.RemoveLabelFromNamespace(f.K8sClient, f.Namespace.GetName(), "foo")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Making sure acrq include only default namespace after removing label")
+			Eventually(func() []string {
+				acrq, err = f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Get(ctx, acrq.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				var namespaces []string
+				for _, ns := range acrq.Status.Namespaces {
+					namespaces = append(namespaces, ns.Namespace)
+				}
+				return namespaces
+			}, 10*time.Second, 1*time.Second).ShouldNot(ContainElements(f.Namespace.Namespace), "acrq should include both default and test namespaces")
+
+			By("Verify pod is not longer effected by acrq")
+			utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		})
+
+		It("Removing a cluster quota should change the quota-namespace mapping and trigger the gate controller", func(ctx context.Context) {
+			acrq := builders.NewAcrqBuilder().
+				WithName("test-quota").
+				WithLabelSelector(labelSelector).
+				WithScopes([]v1.ResourceQuotaScope{v1.ResourceQuotaScopeNotTerminating}).
+				WithResource(v1.ResourceRequestsMemory, resource.MustParse("100Mi")).Build()
+			acrq2 := builders.NewAcrqBuilder().
+				WithName("test-quota2").
+				WithLabelSelector(labelSelector).
+				WithScopes([]v1.ResourceQuotaScope{v1.ResourceQuotaScopeNotTerminating}).
+				WithResource(v1.ResourceRequestsMemory, resource.MustParse("300Mi")).Build()
+
+			By("Creating a ApplicationAwareClusterResourceQuotas")
+			_, err := utils.CreateApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = utils.CreateApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq2)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for the ApplicationAwareClusterResourceQuotas to be propagated")
+			expectedRresources := v1.ResourceList{}
+			expectedRresources[v1.ResourceRequestsMemory] = resource.MustParse("0")
+			err = utils.WaitForApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq.Name, expectedRresources)
+			Expect(err).ToNot(HaveOccurred())
+			err = utils.WaitForApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq2.Name, expectedRresources)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating a pod that should be Gated")
+			podName := "test-pod"
+			requests := v1.ResourceList{}
+			requests[v1.ResourceMemory] = resource.MustParse("200Mi")
+			pod := utils.NewTestPodForQuota(podName, requests, v1.ResourceList{})
+			_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, v12.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+
+			By("Deleting the blocking ApplicationAwareClusterResourceQuota")
+			err = utils.DeleteApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify pod is not longer effected by blocking acrq")
+			utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		})
+	})
+})

--- a/tests/e2e_application_aware_resource_quota_test.go
+++ b/tests/e2e_application_aware_resource_quota_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/application-aware-quota/pkg/aaq-operator/resources"
 	aaqclientset "kubevirt.io/application-aware-quota/pkg/generated/aaq/clientset/versioned"
 	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
@@ -217,10 +216,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests[v1.ResourceEphemeralStorage] = resource.MustParse("30Gi")
 		requests[v1.ResourceName(extendedResourceName)] = resource.MustParse("2")
 		limits[v1.ResourceName(extendedResourceName)] = resource.MustParse("2")
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 		podToUpdate := pod
 
 		By("Ensuring ApplicationAwareResourceQuota status captures the pod usage")
@@ -237,10 +236,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests = v1.ResourceList{}
 		requests[v1.ResourceCPU] = resource.MustParse("600m")
 		requests[v1.ResourceMemory] = resource.MustParse("100Mi")
-		pod = newTestPodForQuota("fail-pod", requests, v1.ResourceList{})
+		pod = utils.NewTestPodForQuota("fail-pod", requests, v1.ResourceList{})
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
 
 		By("Not allowing a pod to be created that exceeds remaining quota(validation on extended resources)")
@@ -251,10 +250,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests[v1.ResourceEphemeralStorage] = resource.MustParse("30Gi")
 		requests[v1.ResourceName(extendedResourceName)] = resource.MustParse("2")
 		limits[v1.ResourceName(extendedResourceName)] = resource.MustParse("2")
-		pod = newTestPodForQuota("fail-pod-for-extended-resource", requests, limits)
+		pod = utils.NewTestPodForQuota("fail-pod-for-extended-resource", requests, limits)
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
 
 		By("Ensuring a pod cannot update its resource requirements")
@@ -615,10 +614,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		limits := v1.ResourceList{}
 		limits[v1.ResourceCPU] = resource.MustParse("1")
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with not terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -653,12 +652,12 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 
 		By("Creating a terminating pod")
 		podName = "terminating-pod"
-		pod = newTestPodForQuota(podName, requests, limits)
+		pod = utils.NewTestPodForQuota(podName, requests, limits)
 		activeDeadlineSeconds := int64(3600)
 		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -712,10 +711,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating a best-effort pod")
-		pod := newTestPodForQuota(podName, v1.ResourceList{}, v1.ResourceList{})
+		pod := utils.NewTestPodForQuota(podName, v1.ResourceList{}, v1.ResourceList{})
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -743,10 +742,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		limits := v1.ResourceList{}
 		limits[v1.ResourceCPU] = resource.MustParse("1")
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
-		pod = newTestPodForQuota("burstable-pod", requests, limits)
+		pod = utils.NewTestPodForQuota("burstable-pod", requests, limits)
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with not best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -811,7 +810,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		Expect(resourceQuotaResult.Spec.Hard).To(HaveKeyWithValue(v1.ResourceMemory, resource.MustParse("1Gi")))
 
 		By("Deleting a ApplicationAwareResourceQuota")
-		err = deleteApplicationAwareResourceQuota(ctx, f.AaqClient, ns, quotaName)
+		err = utils.DeleteApplicationAwareResourceQuota(ctx, f.AaqClient, ns, quotaName)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Verifying the deleted ApplicationAwareResourceQuota")
@@ -1081,10 +1080,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating a best-effort pod")
-		pod := newTestPodForQuota(podName, v1.ResourceList{}, v1.ResourceList{})
+		pod := utils.NewTestPodForQuota(podName, v1.ResourceList{}, v1.ResourceList{})
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1112,10 +1111,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		limits := v1.ResourceList{}
 		limits[v1.ResourceCPU] = resource.MustParse("1")
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
-		pod = newTestPodForQuota("burstable-pod", requests, limits)
+		pod = utils.NewTestPodForQuota("burstable-pod", requests, limits)
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with not best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1165,10 +1164,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		limits := v1.ResourceList{}
 		limits[v1.ResourceCPU] = resource.MustParse("1")
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with not terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1203,12 +1202,12 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 
 		By("Creating a terminating pod")
 		podName = "terminating-pod"
-		pod = newTestPodForQuota(podName, requests, limits)
+		pod = utils.NewTestPodForQuota(podName, requests, limits)
 		activeDeadlineSeconds := int64(3600)
 		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1267,10 +1266,10 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests := v1.ResourceList{}
 		limits := v1.ResourceList{}
 		requests[v1.ResourceMemory] = resource.MustParse("600Mi") //quota has only 500Mi
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Update arq to fit pod")
 		Eventually(func() error {
@@ -1282,7 +1281,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 			_, err = f.AaqClient.AaqV1alpha1().ApplicationAwareResourceQuotas(f.Namespace.Name).Update(ctx, currApplicationAwareResourceQuota, metav1.UpdateOptions{})
 			return err
 		}, 2*time.Minute, 1*time.Second).Should(BeNil())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 	})
 
 	It("should be able to create a ApplicationAwareResourceQuota and gated pod, delete another pod release first pod", func(ctx context.Context) {
@@ -1307,21 +1306,21 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests := v1.ResourceList{}
 		limits := v1.ResourceList{}
 		requests[v1.ResourceMemory] = resource.MustParse("300Mi") //quota has only 500Mi
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Creating a Pod that doesn't fits quota")
 		podName2 := "test-pod2"
-		pod2 := newTestPodForQuota(podName2, requests, limits)
+		pod2 := utils.NewTestPodForQuota(podName2, requests, limits)
 		pod2, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod2.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod2.Name)
 
 		By("Make room by deleting first pod")
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod2.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod2.Name)
 	})
 
 	It("should be able to create a ApplicationAwareResourceQuota and a pod with different gate and release the pod by removing the other gate", func(ctx context.Context) {
@@ -1346,11 +1345,11 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		requests := v1.ResourceList{}
 		limits := v1.ResourceList{}
 		requests[v1.ResourceMemory] = resource.MustParse("300Mi") //quota has only 500Mi
-		pod := newTestPodForQuota(podName, requests, limits)
+		pod := utils.NewTestPodForQuota(podName, requests, limits)
 		pod.Spec.SchedulingGates = []v1.PodSchedulingGate{{"testGate"}}
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Remove test scheduling gate to release pod")
 		Eventually(func() error {
@@ -1362,7 +1361,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 			_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
 			return err
 		}, 2*time.Minute, 1*time.Second).Should(BeNil())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 	})
 
 	It("[Serial] should replace .spec.nodeName with node affinity", Serial, func(ctx context.Context) {
@@ -1497,7 +1496,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass1")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1540,7 +1539,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass2")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1552,7 +1551,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod2 := newTestPodForQuotaWithPriority(f, podName2, v1.ResourceList{}, v1.ResourceList{}, "pclass2")
 		_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, pod2.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod2.Name)
 		err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod2.Name, *metav1.NewDeleteOptions(0))
 
 		By("Deleting first pod")
@@ -1591,7 +1590,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass3")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope remains same")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1603,7 +1602,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod2 := newTestPodForQuotaWithPriority(f, podName2, v1.ResourceList{}, v1.ResourceList{}, "pclass3")
 		pod2, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope remains same")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1646,7 +1645,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass5")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1658,7 +1657,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod2 := newTestPodForQuotaWithPriority(f, podName2, v1.ResourceList{}, v1.ResourceList{}, "pclass6")
 		pod2, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("2")
@@ -1702,7 +1701,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass7")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class is not used")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1739,7 +1738,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass8")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1796,7 +1795,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		pod := newTestPodForQuotaWithPriority(f, podName, request, limit, "pclass9")
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1845,7 +1844,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 				}}}})
 		pod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Creating a pod that uses namespaces field")
 		podWithNamespaces := newTestPodWithAffinityForQuota(f, "with-namespaces", &v1.Affinity{
@@ -1856,7 +1855,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 				}}}})
 		podWithNamespaces, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaces, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota captures podWithNamespaces usage")
 		wantUsedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1879,7 +1878,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 					}}}}})
 		podWithNamespaceSelector, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaceSelector, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+		utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 
 		By("Ensuring Application Aware Resource Quota captures podWithNamespaceSelector usage")
 		wantUsedResources[v1.ResourcePods] = resource.MustParse("2")
@@ -1929,7 +1928,7 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 		}
 		blockedPod, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(ctx, blockedPod, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		verifyPodIsGated(f.K8sClient, f.Namespace.Name, blockedPod.Name)
+		utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, blockedPod.Name)
 		f.ExpectEvent(blockedPod.Namespace).Should(ContainSubstring("exceeded quota"))
 
 	})
@@ -2026,32 +2025,6 @@ func newTestApplicationAwareResourceQuota(name string) *v1alpha1.ApplicationAwar
 	}
 }
 
-// newTestPodForQuota returns a pod that has the specified requests and limits
-func newTestPodForQuota(name string, requests v1.ResourceList, limits v1.ResourceList) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.PodSpec{
-			// prevent disruption to other test workloads in parallel test runs by ensuring the quota
-			// test pods don't get scheduled onto a node
-			NodeSelector: map[string]string{
-				"x-test.k8s.io/unsatisfiable": "not-schedulable",
-			},
-			Containers: []v1.Container{
-				{
-					Name:  "pause",
-					Image: "busybox",
-					Resources: v1.ResourceRequirements{
-						Requests: requests,
-						Limits:   limits,
-					},
-				},
-			},
-		},
-	}
-}
-
 // newTestPodForQuotaWithPriority returns a pod that has the specified requests, limits and priority class
 func newTestPodForQuotaWithPriority(f *framework.Framework, name string, requests v1.ResourceList, limits v1.ResourceList, pclass string) *v1.Pod {
 	return &v1.Pod{
@@ -2079,7 +2052,7 @@ func newTestPodForQuotaWithPriority(f *framework.Framework, name string, request
 	}
 }
 
-// newTestPodForQuota returns a pod that has the specified requests and limits
+// utils.NewTestPodForQuota returns a pod that has the specified requests and limits
 func newTestPodWithAffinityForQuota(f *framework.Framework, name string, affinity *v1.Affinity) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2234,16 +2207,6 @@ func createApplicationAwareResourceQuota(ctx context.Context, c *aaqclientset.Cl
 	return c.AaqV1alpha1().ApplicationAwareResourceQuotas(namespace).Create(ctx, ApplicationAwareResourceQuota, metav1.CreateOptions{})
 }
 
-// createApplicationAwareClusterResourceQuota in the specified namespace
-func createApplicationAwareClusterResourceQuota(ctx context.Context, c *aaqclientset.Clientset, namespace string, ApplicationAwareClusterResourceQuota *v1alpha1.ApplicationAwareClusterResourceQuota) (*v1alpha1.ApplicationAwareClusterResourceQuota, error) {
-	return c.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Create(ctx, ApplicationAwareClusterResourceQuota, metav1.CreateOptions{})
-}
-
-// deleteApplicationAwareResourceQuota with the specified name
-func deleteApplicationAwareResourceQuota(ctx context.Context, c *aaqclientset.Clientset, namespace, name string) error {
-	return c.AaqV1alpha1().ApplicationAwareResourceQuotas(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-}
-
 // countApplicationAwareResourceQuota counts the number of ApplicationAwareResourceQuota in the specified namespace
 // On contended servers the service account controller can slow down, leading to the count changing during a run.
 // Wait up to 5s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
@@ -2320,37 +2283,4 @@ func unstructuredToApplicationAwareResourceQuota(obj *unstructured.Unstructured)
 	err = runtime.DecodeInto(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), json, rq)
 
 	return rq, err
-}
-
-func verifyPodIsGated(c kubernetes.Interface, podNamespace, podName string) {
-	// Retry every 1 seconds
-	EventuallyWithOffset(1, func() bool {
-		// Consistently retry every 1 second for ~10 seconds
-		success := true
-		for i := 0; i < 10; i++ {
-			if !utils.PodSchedulingGated(c, podNamespace, podName) {
-				success = false
-				break
-			}
-
-			time.Sleep(1 * time.Second)
-		}
-		return success
-	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
-}
-
-func verifyPodIsNotGated(c kubernetes.Interface, podNamespace, podName string) {
-	// Retry every 1 seconds
-	EventuallyWithOffset(1, func() bool {
-		// Consistently retry every 1 second for ~10 seconds
-		success := true
-		for i := 0; i < 10; i++ {
-			if utils.PodSchedulingGated(c, podNamespace, podName) {
-				success = false
-				break
-			}
-			time.Sleep(1 * time.Second)
-		}
-		return success
-	}, 2*time.Minute, 1*time.Second).Should(BeTrue())
 }

--- a/tests/utils/aaq-utils.go
+++ b/tests/utils/aaq-utils.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"kubevirt.io/application-aware-quota/pkg/util"
 	aaqv1 "kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	"kubevirt.io/application-aware-quota/tests/framework"
 )
@@ -17,4 +19,15 @@ func GetAAQ(f *framework.Framework) (*aaqv1.AAQ, error) {
 		return nil, fmt.Errorf("should have only single aaq")
 	}
 	return &aaqs.Items[0], nil
+}
+
+func AaqControllerReady(clientset *kubernetes.Clientset, aaqInstallNs string) (bool, error) {
+	deployment, err := clientset.AppsV1().Deployments(aaqInstallNs).Get(context.TODO(), util.ControllerPodName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if *deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
+		return false, nil
+	}
+	return true, nil
 }

--- a/tests/utils/acrq-utils.go
+++ b/tests/utils/acrq-utils.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	aaqclientset "kubevirt.io/application-aware-quota/pkg/generated/aaq/clientset/versioned"
+	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
+	"time"
+)
+
+const (
+	// how long to wait for a Application Aware Resource Quota update to occur
+	resourceQuotaTimeout = 2 * time.Minute
+)
+
+// CreateApplicationAwareClusterResourceQuota in the specified namespace
+func CreateApplicationAwareClusterResourceQuota(ctx context.Context, c *aaqclientset.Clientset, ApplicationAwareClusterResourceQuota *v1alpha1.ApplicationAwareClusterResourceQuota) (*v1alpha1.ApplicationAwareClusterResourceQuota, error) {
+	return c.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Create(ctx, ApplicationAwareClusterResourceQuota, metav1.CreateOptions{})
+}
+
+// DeleteApplicationAwareClusterResourceQuota with the specified name
+func DeleteApplicationAwareClusterResourceQuota(ctx context.Context, c *aaqclientset.Clientset, name string) error {
+	return c.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// wait for Application Aware Cluster Resource Quota status to show the expected used resources value
+func WaitForApplicationAwareClusterResourceQuota(ctx context.Context, c *aaqclientset.Clientset, quotaName string, used v1.ResourceList) error {
+	return wait.PollWithContext(ctx, 2*time.Second, resourceQuotaTimeout, func(ctx context.Context) (bool, error) {
+		ApplicationAwareResourceQuota, err := c.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Get(ctx, quotaName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		// used may not yet be calculated
+		if ApplicationAwareResourceQuota.Status.Total.Used == nil {
+			return false, nil
+		}
+		// verify that the quota shows the expected used resource values
+		for k, v := range used {
+			if actualValue, found := ApplicationAwareResourceQuota.Status.Total.Used[k]; !found || (actualValue.Cmp(v) != 0) {
+				fmt.Printf(fmt.Sprintf("resource %s, expected %s, actual %s\n", k, v.String(), actualValue.String()))
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}

--- a/tests/utils/namespace-utils.go
+++ b/tests/utils/namespace-utils.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// AddLabelToNamespace adds a label to the specified namespace
+func AddLabelToNamespace(clientset *kubernetes.Clientset, namespace, key, value string) error {
+	// Get the namespace object
+	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, v12.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting namespace %s: %v", namespace, err)
+	}
+
+	// Add the label to the namespace
+	if ns.Labels == nil {
+		ns.Labels = make(map[string]string)
+	}
+	ns.Labels[key] = value
+
+	// Update the namespace
+	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, v12.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error updating namespace %s: %v", namespace, err)
+	}
+
+	return nil
+}
+
+// RemoveLabelFromNamespace removes a label from the specified namespace
+func RemoveLabelFromNamespace(clientset *kubernetes.Clientset, namespace, key string) error {
+	// Get the namespace object
+	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, v12.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting namespace %s: %v", namespace, err)
+	}
+
+	// Remove the label from the namespace
+	if _, ok := ns.Labels[key]; ok {
+		delete(ns.Labels, key)
+	}
+
+	// Update the namespace
+	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, v12.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error updating namespace %s: %v", namespace, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes the gate controller miss some events as they do not appear
in the namespace-quotas mapping.
Adding the gate controller as an observer would help making sure
it receive and being triggered by changes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
