### PR TITLE
ARQ-Controller,RQ-Controller: Bugfix arq should be enqueued when arq.spec.scope/arq.status.hard are modifed

### DIFF
--- a/pkg/aaq-controller/arq-controller/arq-controller.go
+++ b/pkg/aaq-controller/arq-controller/arq-controller.go
@@ -192,13 +192,8 @@ func (ctrl *ArqController) enqueueAll() {
 		ctrl.arqQueue.Add(key)
 	}
 }
-func (ctrl *ArqController) updateArq(old, curr interface{}) {
-	oldArq := old.(*v1alpha12.ApplicationAwareResourceQuota)
-	curArq := curr.(*v1alpha12.ApplicationAwareResourceQuota)
-	if quota.Equals(oldArq.Spec.Hard, curArq.Spec.Hard) {
-		return
-	}
-	ctrl.addQuota(ctrl.logger, curArq)
+func (ctrl *ArqController) updateArq(_, curr interface{}) {
+	ctrl.addQuota(ctrl.logger, curr.(*v1alpha12.ApplicationAwareResourceQuota))
 }
 
 func (ctrl *ArqController) addArq(obj interface{}) {

--- a/pkg/aaq-controller/rq-controller/rq-controller.go
+++ b/pkg/aaq-controller/rq-controller/rq-controller.go
@@ -94,18 +94,12 @@ func (ctrl *RQController) addArq(obj interface{}) {
 }
 
 // When a ApplicationAwareResourceQuota is updated, enqueue all gated pods for revaluation
-func (ctrl *RQController) updateArq(old, cur interface{}) {
-	curArq := cur.(*v1alpha12.ApplicationAwareResourceQuota)
-	oldArq := old.(*v1alpha12.ApplicationAwareResourceQuota)
-
-	if !quota.Equals(curArq.Spec.Hard, oldArq.Spec.Hard) {
-		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(curArq)
-		if err != nil {
-			return
-		}
-		ctrl.arqQueue.Add(key)
+func (ctrl *RQController) updateArq(_, cur interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(cur.(*v1alpha12.ApplicationAwareResourceQuota))
+	if err != nil {
+		return
 	}
-
+	ctrl.arqQueue.Add(key)
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is the reason that "should apply changes to a ApplicationAwareResourceQuota status" test is flacky

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
