### PR TITLE
Add a wildcard NoSchedule toleration for pods with .spec.nodeName set

### DIFF
--- a/pkg/aaq-server/handler/handler.go
+++ b/pkg/aaq-server/handler/handler.go
@@ -227,11 +227,9 @@ func generatePatchesForPodWithNodeName(pod v1.Pod) []patch.PatchOperation {
 	}
 
 	affinity := pod.Spec.Affinity
-	affinityPatchOp := patch.PatchReplaceOp
 
 	if affinity == nil {
 		affinity = &v1.Affinity{}
-		affinityPatchOp = patch.PatchAddOp
 	}
 	if affinity.NodeAffinity == nil {
 		affinity.NodeAffinity = &v1.NodeAffinity{}
@@ -264,7 +262,7 @@ func generatePatchesForPodWithNodeName(pod v1.Pod) []patch.PatchOperation {
 
 	return []patch.PatchOperation{
 		{
-			Op:    affinityPatchOp,
+			Op:    patch.PatchAddOp,
 			Path:  "/spec/affinity",
 			Value: affinity,
 		},

--- a/pkg/aaq-server/handler/handler.go
+++ b/pkg/aaq-server/handler/handler.go
@@ -252,6 +252,16 @@ func generatePatchesForPodWithNodeName(pod v1.Pod) []patch.PatchOperation {
 		},
 	)
 
+	tolerations := pod.Spec.Tolerations
+	if tolerations == nil {
+		tolerations = []v1.Toleration{}
+	}
+	tolerations = append(tolerations, v1.Toleration{
+		Key:      "", // i.e. any key
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	})
+
 	return []patch.PatchOperation{
 		{
 			Op:    affinityPatchOp,
@@ -262,6 +272,11 @@ func generatePatchesForPodWithNodeName(pod v1.Pod) []patch.PatchOperation {
 			Op:    patch.PatchReplaceOp,
 			Path:  "/spec/nodeName",
 			Value: "",
+		},
+		{
+			Op:    patch.PatchAddOp,
+			Path:  "/spec/tolerations",
+			Value: tolerations,
 		},
 	}
 }

--- a/pkg/aaq-server/handler/handler.go
+++ b/pkg/aaq-server/handler/handler.go
@@ -85,46 +85,7 @@ func (v Handler) mutatePod() (*admissionv1.AdmissionReview, error) {
 		},
 	}
 
-	if pod.Spec.NodeName != "" {
-		affinity := pod.Spec.Affinity
-		affinityPatchOp := patch.PatchReplaceOp
-
-		if affinity == nil {
-			affinity = &v1.Affinity{}
-			affinityPatchOp = patch.PatchAddOp
-		}
-		if affinity.NodeAffinity == nil {
-			affinity.NodeAffinity = &v1.NodeAffinity{}
-		}
-		if affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
-		}
-		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-			affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			v1.NodeSelectorTerm{
-				MatchFields: []v1.NodeSelectorRequirement{
-					{
-						Key:      "metadata.name",
-						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{pod.Spec.NodeName},
-					},
-				},
-			},
-		)
-
-		patches = append(patches,
-			patch.PatchOperation{
-				Op:    affinityPatchOp,
-				Path:  "/spec/affinity",
-				Value: affinity,
-			},
-			patch.PatchOperation{
-				Op:    patch.PatchReplaceOp,
-				Path:  "/spec/nodeName",
-				Value: "",
-			},
-		)
-	}
+	patches = append(patches, generatePatchesForPodWithNodeName(pod)...)
 
 	patchBytes, err := patch.GeneratePatchPayload(patches...)
 	if err != nil {
@@ -258,4 +219,49 @@ func getResourcesNames(resourceList v1.ResourceList) []v1.ResourceName {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+func generatePatchesForPodWithNodeName(pod v1.Pod) []patch.PatchOperation {
+	if pod.Spec.NodeName == "" {
+		return nil
+	}
+
+	affinity := pod.Spec.Affinity
+	affinityPatchOp := patch.PatchReplaceOp
+
+	if affinity == nil {
+		affinity = &v1.Affinity{}
+		affinityPatchOp = patch.PatchAddOp
+	}
+	if affinity.NodeAffinity == nil {
+		affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	if affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+	}
+	affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		v1.NodeSelectorTerm{
+			MatchFields: []v1.NodeSelectorRequirement{
+				{
+					Key:      "metadata.name",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{pod.Spec.NodeName},
+				},
+			},
+		},
+	)
+
+	return []patch.PatchOperation{
+		{
+			Op:    affinityPatchOp,
+			Path:  "/spec/affinity",
+			Value: affinity,
+		},
+		{
+			Op:    patch.PatchReplaceOp,
+			Path:  "/spec/nodeName",
+			Value: "",
+		},
+	}
 }

--- a/tests/e2e_application_aware_resource_quota_test.go
+++ b/tests/e2e_application_aware_resource_quota_test.go
@@ -1472,34 +1472,30 @@ var _ = Describe("ApplicationAwareResourceQuota", func() {
 					return err
 				}
 
-				if pod.Spec.Affinity == nil {
-					return fmt.Errorf("pod affinity is nil")
-				}
-
-				expectedNodeSelectorTerm := v1.NodeSelectorTerm{
-					MatchFields: []v1.NodeSelectorRequirement{
-						{
-							Key:      "metadata.name",
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{*nodeName},
-						},
-					},
-				}
-				nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-
-				found := false
-				for _, nodeSelectorTerm := range nodeSelectorTerms {
-					if apiequality.Semantic.DeepEqual(nodeSelectorTerm, expectedNodeSelectorTerm) {
-						found = true
-					}
-				}
-
-				if !found {
-					return fmt.Errorf("did not found expected node affinity")
-				}
-
 				return nil
 			}, 2*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+
+			Expect(pod.Spec.Affinity).ToNot(BeNil())
+
+			expectedNodeSelectorTerm := v1.NodeSelectorTerm{
+				MatchFields: []v1.NodeSelectorRequirement{
+					{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{*nodeName},
+					},
+				},
+			}
+			nodeSelectorTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+
+			found := false
+			for _, nodeSelectorTerm := range nodeSelectorTerms {
+				if apiequality.Semantic.DeepEqual(nodeSelectorTerm, expectedNodeSelectorTerm) {
+					found = true
+				}
+			}
+
+			Expect(found).To(BeTrue(), "did not found expected node affinity")
 
 			By("Ensuring the pod landed on the right node")
 			Eventually(func() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to https://github.com/kubevirt/application-aware-quota/pull/28.
`kubectl debug` can be used for nodes that taints. Bypass taints for such nodes with a wildcard NoSchedule tolerration.

Another alternative to consider is to dismiss pods with nodeName set altogether, which is implemented here: https://github.com/kubevirt/application-aware-quota/pull/46.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a wildcard NoSchedule toleration for pods with .spec.nodeName set
```
