### PR TITLE
Add requirement for release tool for safe publishing

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+source $(dirname "$0")/build/common.sh
+source $(dirname "$0")/build/config.sh
+
+set -e
+
+if [ -z "${AAQ_CRI}" ]; then
+    echo >&2 "no working container runtime found. Neither docker nor podman seems to work."
+    exit 1
+fi
+
+if [ -z ${GPG_PRIVATE_KEY_FILE} ]; then
+    echo "GPG_PRIVATE_KEY_FILE env var must be set"
+    exit 1
+elif [ -z ${GPG_PASSPHRASE_FILE} ]; then
+    echo "GPG_PASSPHRASE_FILE env var must be set"
+    exit 1
+elif [ -z ${GITHUB_API_TOKEN_FILE} ]; then
+    echo "GITHUB_API_TOKEN_FILE env var must be set"
+    exit 1
+fi
+
+GIT_USER=${GIT_USER:-$(git config user.name)}
+GIT_EMAIL=${GIT_EMAIL:-$(git config user.email)}
+
+echo "git user:  $GIT_USER"
+echo "git email: $GIT_EMAIL"
+
+${AAQ_CRI} pull quay.io/kubevirtci/release-tool:latest
+
+echo "${AAQ_CRI} run -it --rm \
+-v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
+-v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
+-v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \
+-v /home/.gitconfig:/home/releaser/.gitconfig \
+quay.io/kubevirtci/release-tool:latest \
+--org=kubevirt \
+--repo=application-aware-quota \
+--git-email \"${GIT_EMAIL}\" \
+--git-user \"${GIT_USER}\"
+\"$@\""
+
+${AAQ_CRI} run -it --rm \
+    -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
+    -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
+    -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \
+    -v /home/.gitconfig:/home/.gitconfig \
+    quay.io/kubevirtci/release-tool:latest \
+    --org=kubevirt \
+    --repo=application-aware-quota \
+    --git-email "${GIT_EMAIL}" \
+    --git-user "${GIT_USER}" \
+    "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The current process for creating a Z-stream release for AAQ requires us to force push a new tag.

This approach is not safe, as it requires manual push to the AAQ repository and can cause issues like the one mentioned [here](https://github.com/kubevirt/application-aware-quota/pull/51#issuecomment-2071948516).

To avoid this, we should align with the `kubevirt/kubevirt` project and utilize [the release tool](https://github.com/kubevirt/kubevirt/blob/main/docs/release-procedure.md#creating-new-patch-releases).
This PR adds a requirement script to use the release tool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
