### PR TITLE
BUGFIX: Do not release pods in terminating namespaces.

### DIFF
--- a/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
+++ b/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
@@ -260,10 +260,11 @@ func (ctrl *AaqGateController) Execute() bool {
 }
 
 func (ctrl *AaqGateController) execute(ns string) (error, enqueueState) {
-	_, err := ctrl.namespaceLister.Get(ns)
-	if kapierrors.IsNotFound(err) {
+	namespace, err := ctrl.namespaceLister.Get(ns)
+	if kapierrors.IsNotFound(err) || namespace.Status.Phase == v1.NamespaceTerminating {
 		return nil, Forget
 	}
+
 	aaqjqc, err := ctrl.createAndGetAaqjqc(ns)
 	if err != nil {
 		return err, Immediate


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a namespace is in the 'Terminating' phase,
it means that Kubernetes is in the process
of removing all resources from that namespace.

We should not attempt to release pods in
such namespaces.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
