### PR TITLE
Change default label name to enable-gating

### DIFF
--- a/pkg/aaq-operator/resources/cluster/aaqserver.go
+++ b/pkg/aaq-operator/resources/cluster/aaqserver.go
@@ -17,7 +17,7 @@ const (
 	MutatingWebhookConfigurationName   = "gating-mutator"
 	validatingWebhookConfigurationName = "aaq-validator"
 	AaqServerServiceName               = "aaq-server"
-	DefaultNamespaceSelectorLabel      = "application-aware-quota/enable"
+	DefaultNamespaceSelectorLabel      = "application-aware-quota/enable-gating"
 )
 
 func createStaticAAQLockResources(args *FactoryArgs) []client.Object {

--- a/pkg/aaq-operator/resources/crds_generated.go
+++ b/pkg/aaq-operator/resources/crds_generated.go
@@ -2367,7 +2367,7 @@ spec:
                 type: object
               namespaceSelector:
                 description: namespaces where pods should be gated before scheduling
-                  Defaults to targeting namespaces with an "application-aware-quota/enable"
+                  Defaults to targeting namespaces with an "application-aware-quota/enable-gating"
                   label key.
                 properties:
                   matchExpressions:

--- a/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
@@ -145,7 +145,7 @@ type AAQSpec struct {
 	// PriorityClass of the AAQ control plane
 	PriorityClass *AAQPriorityClass `json:"priorityClass,omitempty"`
 	// namespaces where pods should be gated before scheduling
-	// Defaults to targeting namespaces with an "application-aware-quota/enable" label key.
+	// Defaults to targeting namespaces with an "application-aware-quota/enable-gating" label key.
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 	// holds aaq configurations.
 	Configuration AAQConfiguration `json:"configuration,omitempty"`


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The default label suggest that this is
where gating will take place AAQ would
still force non schedulable resources
boundaries therefore enable-gating
is a better name.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change default label name to application-aware-quota/enable-gating
```
