### PR TITLE
Add an automated mechanism to detect namespaces where a SchedulingGate should be added

### DIFF
--- a/cmd/aaq-operator/aaq-operator.go
+++ b/cmd/aaq-operator/aaq-operator.go
@@ -28,10 +28,12 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
+/*
 func init() {
 	// Define a flag named "v" with a default value of false and a usage message.
 	flag.String("v", defVerbose, "Verbosity level")
 }
+*/
 
 func main() {
 	flag.Parse()

--- a/pkg/aaq-operator/cr-manager.go
+++ b/pkg/aaq-operator/cr-manager.go
@@ -73,6 +73,8 @@ func (r *ReconcileAAQ) getNamespacedArgs(cr *aaqv1.AAQ) *aaqnamespaced.FactoryAr
 		}
 		result.InfraNodePlacement = &cr.Spec.Infra
 		result.Client = r.client
+		result.AllowApplicationAwareClusterResourceQuota = cr.Spec.Configuration.AllowApplicationAwareClusterResourceQuota
+		result.VmiCalcConfigName = cr.Spec.Configuration.VmiCalculatorConfiguration.ConfigName
 	}
 
 	return &result

--- a/pkg/aaq-operator/resources/cluster/aaqserver.go
+++ b/pkg/aaq-operator/resources/cluster/aaqserver.go
@@ -60,6 +60,42 @@ func getAaqServerClusterPolicyRules() []rbacv1.PolicyRule {
 				"create",
 			},
 		},
+		{
+			APIGroups: []string{
+				"aaq.kubevirt.io",
+			},
+			Resources: []string{
+				"applicationawareresourcequotas",
+			},
+			Verbs: []string{
+				"watch",
+				"list",
+			},
+		},
+		{
+			APIGroups: []string{
+				"aaq.kubevirt.io",
+			},
+			Resources: []string{
+				"applicationawareclusterresourcequotas",
+			},
+			Verbs: []string{
+				"watch",
+				"list",
+			},
+		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"namespaces",
+			},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		},
 	}
 }
 

--- a/pkg/aaq-operator/resources/crds_generated.go
+++ b/pkg/aaq-operator/resources/crds_generated.go
@@ -2366,9 +2366,7 @@ spec:
                     type: array
                 type: object
               namespaceSelector:
-                description: namespaces where pods should be gated before scheduling
-                  Defaults to targeting namespaces with an "application-aware-quota/enable-gating"
-                  label key.
+                description: 'Deprecated: This field is ignored.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/aaq-operator/resources/namespaced/aaqserver.go
+++ b/pkg/aaq-operator/resources/namespaced/aaqserver.go
@@ -21,7 +21,7 @@ func createAAQServerResources(args *FactoryArgs) []client.Object {
 		createAAQServerRoleBinding(),
 		createAAQServerServiceAccount(),
 		createAAQServerService(),
-		createAAQServerDeployment(args.AaqServerImage, args.PullPolicy, args.ImagePullSecrets, args.PriorityClassName, args.Verbosity, args.InfraNodePlacement, args.OnOpenshift),
+		createAAQServerDeployment(args.AaqServerImage, args.PullPolicy, args.ImagePullSecrets, args.PriorityClassName, args.Verbosity, args.InfraNodePlacement, args.OnOpenshift, args.AllowApplicationAwareClusterResourceQuota),
 	}
 }
 
@@ -45,7 +45,7 @@ func createAAQServerService() *corev1.Service {
 	return service
 }
 
-func createAAQServerDeployment(image, pullPolicy string, imagePullSecrets []corev1.LocalObjectReference, priorityClassName string, verbosity string, infraNodePlacement *sdkapi.NodePlacement, onOpenshift bool) *appsv1.Deployment {
+func createAAQServerDeployment(image, pullPolicy string, imagePullSecrets []corev1.LocalObjectReference, priorityClassName string, verbosity string, infraNodePlacement *sdkapi.NodePlacement, onOpenshift bool, enableClusterQuota bool) *appsv1.Deployment {
 	defaultMode := corev1.ConfigMapVolumeSourceDefaultMode
 	deployment := utils2.CreateDeployment(utils2.AaqServerResourceName, utils2.AAQLabel, utils2.AaqServerResourceName, utils2.AaqServerResourceName, imagePullSecrets, 2, infraNodePlacement)
 	if priorityClassName != "" {
@@ -62,6 +62,9 @@ func createAAQServerDeployment(image, pullPolicy string, imagePullSecrets []core
 	container.Ports = createAAQServerPorts()
 	if onOpenshift {
 		container.Args = append(container.Args, []string{"--" + utils2.IsOnOpenshift, "true"}...)
+	}
+	if enableClusterQuota {
+		container.Args = append(container.Args, []string{"--" + utils2.EnableClusterQuota, "true"}...)
 	}
 	container.Env = []corev1.EnvVar{
 		{

--- a/pkg/aaq-operator/resources/namespaced/controller.go
+++ b/pkg/aaq-operator/resources/namespaced/controller.go
@@ -16,15 +16,11 @@ import (
 )
 
 func createAAQControllerResources(args *FactoryArgs) []client.Object {
-	cr, _ := utils2.GetActiveAAQ(args.Client)
-	if cr == nil {
-		return nil
-	}
 	return []client.Object{
 		createAAQControllerServiceAccount(),
 		createControllerRoleBinding(),
 		createControllerRole(),
-		createAAQControllerDeployment(args.ControllerImage, args.Verbosity, args.PullPolicy, args.ImagePullSecrets, args.PriorityClassName, args.InfraNodePlacement, cr.Spec.Configuration.AllowApplicationAwareClusterResourceQuota, args.OnOpenshift, cr.Spec.Configuration.VmiCalculatorConfiguration.ConfigName, args.Client),
+		createAAQControllerDeployment(args.ControllerImage, args.Verbosity, args.PullPolicy, args.ImagePullSecrets, args.PriorityClassName, args.InfraNodePlacement, args.AllowApplicationAwareClusterResourceQuota, args.OnOpenshift, args.VmiCalcConfigName, args.Client),
 	}
 }
 func createControllerRoleBinding() *rbacv1.RoleBinding {

--- a/pkg/aaq-operator/resources/namespaced/factory.go
+++ b/pkg/aaq-operator/resources/namespaced/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 	utils "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -11,18 +12,20 @@ import (
 
 // FactoryArgs contains the required parameters to generate all namespaced resources
 type FactoryArgs struct {
-	OperatorVersion        string `required:"true" split_words:"true"`
-	ControllerImage        string `required:"true" split_words:"true"`
-	DeployClusterResources string `required:"true" split_words:"true"`
-	AaqServerImage         string `required:"true" split_words:"true"`
-	Verbosity              string `required:"true"`
-	PullPolicy             string `required:"true" split_words:"true"`
-	ImagePullSecrets       []corev1.LocalObjectReference
-	PriorityClassName      string
-	Namespace              string
-	InfraNodePlacement     *sdkapi.NodePlacement
-	OnOpenshift            bool
-	Client                 client.Client
+	OperatorVersion                           string `required:"true" split_words:"true"`
+	ControllerImage                           string `required:"true" split_words:"true"`
+	DeployClusterResources                    string `required:"true" split_words:"true"`
+	AaqServerImage                            string `required:"true" split_words:"true"`
+	Verbosity                                 string `required:"true"`
+	PullPolicy                                string `required:"true" split_words:"true"`
+	ImagePullSecrets                          []corev1.LocalObjectReference
+	PriorityClassName                         string
+	Namespace                                 string
+	InfraNodePlacement                        *sdkapi.NodePlacement
+	OnOpenshift                               bool
+	Client                                    client.Client
+	AllowApplicationAwareClusterResourceQuota bool
+	VmiCalcConfigName                         v1alpha1.VmiCalcConfigName
 }
 
 type factoryFunc func(*FactoryArgs) []client.Object

--- a/pkg/aaq-server/aaq-server_test.go
+++ b/pkg/aaq-server/aaq-server_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Test aaq serve functions", func() {
 			secretCertManager,
 			cli,
 			false,
+			&fakeNamespaceChecker{},
 		)
 		req, err := http.NewRequest("GET", healthzPath, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -67,6 +68,7 @@ var _ = Describe("Test aaq serve functions", func() {
 			secretCertManager,
 			cli,
 			false,
+			&fakeNamespaceChecker{},
 		)
 
 		// Create a new ApplicationAwareResourceQuota create request
@@ -127,3 +129,10 @@ var _ = Describe("Test aaq serve functions", func() {
 		Expect(status).To(Equal(http.StatusOK))
 	})
 })
+
+type fakeNamespaceChecker struct {
+}
+
+func (qnsc *fakeNamespaceChecker) IsSelectedNamespace(ns string) bool {
+	return true
+}

--- a/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq-selected-namespaces-controller.go
+++ b/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq-selected-namespaces-controller.go
@@ -1,0 +1,149 @@
+package arq_selected_namespaces_controller
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"kubevirt.io/application-aware-quota/pkg/generated/aaq/listers/core/v1alpha1"
+	"kubevirt.io/application-aware-quota/pkg/log"
+	v1alpha12 "kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
+	"sync"
+	"time"
+)
+
+type NamespaceSet struct {
+	m sync.Map
+}
+
+func (s *NamespaceSet) Add(ns string) {
+	s.m.Store(ns, true)
+}
+
+func (s *NamespaceSet) Remove(ns string) {
+	s.m.Delete(ns)
+}
+
+func (s *NamespaceSet) Contains(ns string) bool {
+	_, ok := s.m.Load(ns)
+	return ok
+}
+
+type enqueueState string
+
+const (
+	Immediate enqueueState = "Immediate"
+	Forget    enqueueState = "Forget"
+	BackOff   enqueueState = "BackOff"
+)
+
+type ArqSelectedNamespacesController struct {
+	nsSet     NamespaceSet
+	arqLister v1alpha1.ApplicationAwareResourceQuotaLister
+	nsQueue   workqueue.RateLimitingInterface
+	stop      <-chan struct{}
+}
+
+func NewArqSelectedNamespacesController(
+	arqInformer cache.SharedIndexInformer,
+	stop <-chan struct{},
+) *ArqSelectedNamespacesController {
+	ctrl := &ArqSelectedNamespacesController{
+		arqLister: v1alpha1.NewApplicationAwareResourceQuotaLister(arqInformer.GetIndexer()),
+		nsQueue:   workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: "ns_queue"}),
+		stop:      stop,
+	}
+
+	arqInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    ctrl.addArq,
+			UpdateFunc: ctrl.updateArq,
+			DeleteFunc: ctrl.deleteArq,
+		},
+	)
+
+	return ctrl
+}
+
+func (ctrl *ArqSelectedNamespacesController) updateArq(_, curr interface{}) {
+	arq := curr.(*v1alpha12.ApplicationAwareResourceQuota)
+	ctrl.nsQueue.Add(arq.Namespace)
+}
+
+func (ctrl *ArqSelectedNamespacesController) addArq(obj interface{}) {
+	arq := obj.(*v1alpha12.ApplicationAwareResourceQuota)
+	ctrl.nsQueue.Add(arq.Namespace)
+}
+
+func (ctrl *ArqSelectedNamespacesController) deleteArq(obj interface{}) {
+	arq := obj.(*v1alpha12.ApplicationAwareResourceQuota)
+	ctrl.nsQueue.Add(arq.Namespace)
+}
+
+func (ctrl *ArqSelectedNamespacesController) runWorker() {
+	for ctrl.Execute() {
+	}
+}
+
+func (ctrl *ArqSelectedNamespacesController) Execute() bool {
+	ns, quit := ctrl.nsQueue.Get()
+	if quit {
+		return false
+	}
+	defer ctrl.nsQueue.Done(ns)
+	enqueueState, err := ctrl.execute(ns.(string))
+
+	if err != nil {
+		log.Log.Infof(fmt.Sprintf("ArqSelectedNamespacesController: Error with key: %v err: %v", ns, err))
+	}
+	switch enqueueState {
+	case BackOff:
+		ctrl.nsQueue.AddRateLimited(ns)
+	case Forget:
+		ctrl.nsQueue.Forget(ns)
+	case Immediate:
+		ctrl.nsQueue.Add(ns)
+	}
+
+	return true
+}
+
+func (ctrl *ArqSelectedNamespacesController) execute(ns string) (enqueueState, error) {
+	arqs, err := ctrl.arqLister.ApplicationAwareResourceQuotas(ns).List(labels.Everything())
+	if err != nil {
+		return Immediate, err
+	}
+	if len(arqs) > 0 {
+		ctrl.nsSet.Add(ns)
+		return Forget, nil
+	}
+
+	ctrl.nsSet.Remove(ns)
+	return Forget, nil
+}
+
+func (ctrl *ArqSelectedNamespacesController) Run(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	klog.Info("Starting ARQ controller")
+	defer klog.Info("Shutting ARQ Controller")
+
+	arqs, _ := ctrl.arqLister.List(labels.Everything())
+	for _, arq := range arqs {
+		ctrl.nsQueue.Add(arq.Namespace)
+	}
+
+	// the workers that chug through the quota calculation backlog
+	for i := 0; i < workers; i++ {
+		go wait.Until(ctrl.runWorker, time.Second, ctrl.stop)
+	}
+
+	<-ctx.Done()
+}
+
+func (ctrl *ArqSelectedNamespacesController) GetNSSet() *NamespaceSet {
+	return &ctrl.nsSet
+}

--- a/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq_selected_namespace_controller_test.go
+++ b/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq_selected_namespace_controller_test.go
@@ -1,0 +1,38 @@
+package arq_selected_namespaces_controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
+	"kubevirt.io/application-aware-quota/tests/builders"
+)
+
+var _ = Describe("Test arq-selected-namespaces-controller", func() {
+	testns := "test-ns"
+	DescribeTable("check namespace selection based on arq existence",
+		func(arqObjects []metav1.Object, expectedContains bool, description string) {
+			arqInformer := testsutils.NewFakeSharedIndexInformer(arqObjects)
+			selectedNamespacesController := setupArqSelectedNamespacesController(arqInformer)
+			result, err := selectedNamespacesController.execute(testns)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(Forget))
+			Expect(selectedNamespacesController.nsSet.Contains(testns)).To(Equal(expectedContains), description)
+		},
+		Entry("namespace is added if arq exists",
+			[]metav1.Object{builders.NewArqBuilder().WithName("arq").WithNamespace(testns).Build()},
+			true, "namespace should be selected when arq exists in it"),
+		Entry("namespace is not added if arq does not exist", []metav1.Object{},
+			false, "namespace should not be selected when arq does not exist in it"),
+	)
+})
+
+func setupArqSelectedNamespacesController(arqInformer cache.SharedIndexInformer) *ArqSelectedNamespacesController {
+	stop := make(chan struct{})
+	qc := NewArqSelectedNamespacesController(
+		arqInformer,
+		stop,
+	)
+	return qc
+}

--- a/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq_selected_namespaces_controller_suite_test.go
+++ b/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller/arq_selected_namespaces_controller_suite_test.go
@@ -1,0 +1,13 @@
+package arq_selected_namespaces_controller_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestArqSelectedNamespacesController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ArqSelectedNamespacesController Suite")
+}

--- a/pkg/aaq-server/select-gating-namespaces/contorllers-executor.go
+++ b/pkg/aaq-server/select-gating-namespaces/contorllers-executor.go
@@ -1,0 +1,138 @@
+package select_gating_namespaces
+
+/*
+ * This file is part of the AAQ project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023,Red Hat, Inc.
+ *
+ */
+
+import (
+	"context"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"kubevirt.io/application-aware-quota/pkg/aaq-controller/additional-cluster-quota-controllers/clusterquotamapping"
+	"kubevirt.io/application-aware-quota/pkg/aaq-server/select-gating-namespaces/arq-selected-namespaces-controller"
+	"kubevirt.io/application-aware-quota/pkg/client"
+	"kubevirt.io/application-aware-quota/pkg/informers"
+	golog "log"
+)
+
+type AaqServerControllerExecutor struct {
+	enableClusterQuota              bool
+	aaqCli                          client.AAQClient
+	arqSelectedNamespacesController *arq_selected_namespaces_controller.ArqSelectedNamespacesController
+	clusterQuotaMappingController   *clusterquotamapping.ClusterQuotaMappingController
+	clusterQuotaMapper              clusterquotamapping.ClusterQuotaMapper
+	safeNamespaceSet                *arq_selected_namespaces_controller.NamespaceSet
+	arqInformer                     cache.SharedIndexInformer
+	acrqInformer                    cache.SharedIndexInformer
+	nsInformer                      cache.SharedIndexInformer
+	stop                            <-chan struct{}
+}
+
+func NewSelectedNamespaceControllerExecutor(clusterQuotaEnabled bool, stop <-chan struct{}) *AaqServerControllerExecutor {
+	var err error
+	var app = &AaqServerControllerExecutor{}
+	app.enableClusterQuota = clusterQuotaEnabled
+
+	app.aaqCli, err = client.GetAAQClient()
+	if err != nil {
+		golog.Fatalf("AAQClient: %v", err)
+	}
+	app.arqInformer = informers.GetApplicationAwareResourceQuotaInformer(app.aaqCli)
+	app.nsInformer = informers.GetNamespaceInformer(app.aaqCli)
+
+	if app.enableClusterQuota {
+		app.acrqInformer = informers.GetApplicationAwareClusterResourceQuotaInformer(app.aaqCli)
+		app.initClusterQuotaMappingController()
+		app.clusterQuotaMapper = app.clusterQuotaMappingController.GetClusterQuotaMapper()
+	}
+
+	app.initArqController()
+
+	return app
+}
+
+func (ce *AaqServerControllerExecutor) initArqController() {
+	ce.arqSelectedNamespacesController = arq_selected_namespaces_controller.NewArqSelectedNamespacesController(
+		ce.arqInformer,
+		ce.stop,
+	)
+}
+
+func (ce *AaqServerControllerExecutor) initClusterQuotaMappingController() {
+	ce.clusterQuotaMappingController = clusterquotamapping.NewClusterQuotaMappingController(
+		ce.nsInformer,
+		ce.acrqInformer,
+		ce.stop,
+	)
+}
+
+func (ce *AaqServerControllerExecutor) Run() {
+	go ce.arqInformer.Run(ce.stop)
+	go ce.nsInformer.Run(ce.stop)
+
+	if !cache.WaitForCacheSync(ce.stop,
+		ce.arqInformer.HasSynced,
+		ce.nsInformer.HasSynced,
+	) {
+		klog.Warningf("failed to wait for caches to sync")
+	}
+	if ce.enableClusterQuota {
+		go ce.acrqInformer.Run(ce.stop)
+		if !cache.WaitForCacheSync(ce.stop,
+			ce.acrqInformer.HasSynced,
+		) {
+			klog.Warningf("failed to wait for caches to sync")
+		}
+		go func() {
+			ce.clusterQuotaMappingController.Run(3)
+		}()
+	}
+
+	go func() {
+		ce.arqSelectedNamespacesController.Run(context.Background(), 3)
+	}()
+}
+
+type QuotaNamespaceChecker interface {
+	IsSelectedNamespace(ns string) bool
+}
+
+type AAQQuotaNamespaceChecker struct {
+	nsSet              *arq_selected_namespaces_controller.NamespaceSet
+	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper
+	enableClusterQuota bool
+}
+
+func (qnsc *AAQQuotaNamespaceChecker) IsSelectedNamespace(ns string) bool {
+	if qnsc.nsSet.Contains(ns) {
+		return true
+	}
+	if qnsc.enableClusterQuota {
+		quotas, _ := qnsc.clusterQuotaMapper.GetClusterQuotasFor(ns)
+		return len(quotas) > 0
+	}
+	return false
+}
+
+func (ce *AaqServerControllerExecutor) GetQuotaNamespaceChecker() QuotaNamespaceChecker {
+	return &AAQQuotaNamespaceChecker{
+		ce.arqSelectedNamespacesController.GetNSSet(),
+		ce.clusterQuotaMapper,
+		ce.enableClusterQuota,
+	}
+}

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -1,0 +1,60 @@
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+const (
+	PatchReplaceOp = "replace"
+	PatchTestOp    = "test"
+	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
+)
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
+}
+
+func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]byte, error) {
+	return GeneratePatchPayload(
+		PatchOperation{
+			Op:    PatchTestOp,
+			Path:  path,
+			Value: oldValue,
+		},
+		PatchOperation{
+			Op:    PatchReplaceOp,
+			Path:  path,
+			Value: newValue,
+		},
+	)
+}
+
+func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
+	var p []PatchOperation
+	err := json.Unmarshal(patch, &p)
+
+	return p, err
+}
+
+func EscapeJSONPointer(ptr string) string {
+	s := strings.ReplaceAll(ptr, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
+}

--- a/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
@@ -144,8 +144,8 @@ type AAQSpec struct {
 	CertConfig *AAQCertConfig `json:"certConfig,omitempty"`
 	// PriorityClass of the AAQ control plane
 	PriorityClass *AAQPriorityClass `json:"priorityClass,omitempty"`
-	// namespaces where pods should be gated before scheduling
-	// Defaults to targeting namespaces with an "application-aware-quota/enable-gating" label key.
+	// +kubebuilder:deprecatedversion:warning="NamespaceSelector field is ignored"
+	// Deprecated: This field is ignored.
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 	// holds aaq configurations.
 	Configuration AAQConfiguration `json:"configuration,omitempty"`

--- a/tests/e2e_application_aware_cluster_resource_quota.go
+++ b/tests/e2e_application_aware_cluster_resource_quota.go
@@ -9,6 +9,7 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kubevirt.io/application-aware-quota/tests/builders"
 	"kubevirt.io/application-aware-quota/tests/framework"
+	"kubevirt.io/application-aware-quota/tests/libaaq"
 	"kubevirt.io/application-aware-quota/tests/utils"
 	"time"
 )
@@ -25,16 +26,8 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 			_, err := f.AaqClient.AaqV1alpha1().AAQs().Update(context.Background(), aaq, v12.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
-				ready, err := utils.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
-				Expect(err).ToNot(HaveOccurred())
-				return ready
-			}, 1*time.Minute, 1*time.Second).ShouldNot(BeTrue(), "config change should trigger redeployment of the controller")
-			Eventually(func() bool {
-				ready, err := utils.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
-				Expect(err).ToNot(HaveOccurred())
-				return ready
+				return libaaq.IsAaqWorkloadsReadyForAtLeast5Seconds(f.K8sClient, f.AAQInstallNs)
 			}, 10*time.Minute, 1*time.Second).Should(BeTrue(), "aaq-controller should be ready with the new config Eventually")
-
 		}
 		labelSelector = &v12.LabelSelector{
 			MatchLabels: map[string]string{"foo": "foo"},

--- a/tests/e2e_application_aware_cluster_resource_quota.go
+++ b/tests/e2e_application_aware_cluster_resource_quota.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	"kubevirt.io/application-aware-quota/tests/builders"
 	"kubevirt.io/application-aware-quota/tests/framework"
 	"kubevirt.io/application-aware-quota/tests/libaaq"
@@ -32,7 +34,6 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 		labelSelector = &v12.LabelSelector{
 			MatchLabels: map[string]string{"foo": "foo"},
 		}
-		// Function to add label to a namespace
 		err = utils.AddLabelToNamespace(f.K8sClient, "default", "foo", "foo")
 		Expect(err).ToNot(HaveOccurred())
 		err = utils.AddLabelToNamespace(f.K8sClient, f.Namespace.GetName(), "foo", "foo")
@@ -63,6 +64,11 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 
 			By("Creating a ApplicationAwareClusterResourceQuota")
 			_, err := utils.CreateApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = utils.AddLabelToNamespace(f.K8sClient, "default", "foo", "foo")
+			Expect(err).ToNot(HaveOccurred())
+			err = utils.AddLabelToNamespace(f.K8sClient, f.Namespace.GetName(), "foo", "foo")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for the ApplicationAwareClusterResourceQuota to be propagated")
@@ -110,6 +116,7 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 		})
 
 		It("Removing a cluster quota should change the quota-namespace mapping and trigger the gate controller", func(ctx context.Context) {
+
 			acrq := builders.NewAcrqBuilder().
 				WithName("test-quota").
 				WithLabelSelector(labelSelector).
@@ -126,7 +133,9 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, err = utils.CreateApplicationAwareClusterResourceQuota(ctx, f.AaqClient, acrq2)
 			Expect(err).ToNot(HaveOccurred())
-
+			By("Add label to include test namespace in the acrq")
+			err = utils.AddLabelToNamespace(f.K8sClient, f.Namespace.GetName(), "foo", "foo")
+			Expect(err).ToNot(HaveOccurred())
 			By("Waiting for the ApplicationAwareClusterResourceQuotas to be propagated")
 			expectedRresources := v1.ResourceList{}
 			expectedRresources[v1.ResourceRequestsMemory] = resource.MustParse("0")
@@ -152,4 +161,56 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota", func() {
 			utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
 		})
 	})
+
+	Context("Test gating with ACRQs", func() {
+		It("Gate should be added to a pod only if acrq is enforced on it and should no longer be added if relevant label is no longer in a namespace", func() {
+			labelSelector := &v12.LabelSelector{
+				MatchLabels: map[string]string{"foo": "foo"},
+			}
+			acrq := builders.NewAcrqBuilder().WithName("acrq").WithResource(v1.ResourcePods, resource.MustParse("0")).WithLabelSelector(labelSelector).Build()
+			_, err := f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Create(context.Background(), acrq, v12.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			pod := utils.NewTestPodForQuota("somepod", v1.ResourceList{}, v1.ResourceList{})
+			for i := 0; i < 3; i++ { //retry 3 times to make sure it is not race-full
+				err := utils.AddLabelToNamespace(f.K8sClient, f.Namespace.GetName(), "foo", "foo")
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					acrq, err := f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Get(context.Background(), acrq.Name, v12.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					if !nsIncludedInAcrq(acrq, f.Namespace.Name) {
+						return fmt.Errorf("acrq should include test ns")
+					}
+					return nil
+				}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+				_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(context.Background(), pod, v12.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				utils.VerifyPodIsGated(f.K8sClient, f.Namespace.Name, pod.Name)
+				err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				err = utils.RemoveLabelFromNamespace(f.K8sClient, f.Namespace.GetName(), "foo")
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					acrq, err := f.AaqClient.AaqV1alpha1().ApplicationAwareClusterResourceQuotas().Get(context.Background(), acrq.Name, v12.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					if nsIncludedInAcrq(acrq, f.Namespace.Name) {
+						return fmt.Errorf("acrq should not include test ns")
+					}
+					return nil
+				}, 1*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
+				_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Create(context.Background(), pod, v12.CreateOptions{})
+				utils.VerifyPodIsNotGated(f.K8sClient, f.Namespace.Name, pod.Name)
+				err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
 })
+
+func nsIncludedInAcrq(acrq *v1alpha1.ApplicationAwareClusterResourceQuota, ns string) bool {
+	for _, acrqns := range acrq.Status.Namespaces {
+		if acrqns.Namespace == ns {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e_mirrors_quotas_test.go
+++ b/tests/e2e_mirrors_quotas_test.go
@@ -215,12 +215,8 @@ var _ = Describe("ApplicationAwareAppliedClusterResourceQuota mirrors Applicatio
 			_, err := f.AaqClient.AaqV1alpha1().AAQs().Update(context.Background(), aaq, v12.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
-				return libaaq.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
+				return libaaq.IsAaqWorkloadsReadyForAtLeast5Seconds(f.K8sClient, f.AAQInstallNs)
 			}, 1*time.Minute, 1*time.Second).ShouldNot(BeTrue(), "config change should trigger redeployment of the controller")
-			Eventually(func() bool {
-				return libaaq.AaqControllerReady(f.K8sClient, f.AAQInstallNs)
-			}, 10*time.Minute, 1*time.Second).Should(BeTrue(), "aaq-controller should be ready with the new config Eventually")
-
 		}
 		labelSelector = &v12.LabelSelector{
 			MatchLabels: map[string]string{"foo": "foo"},

--- a/tests/utils/aaq-utils.go
+++ b/tests/utils/aaq-utils.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"kubevirt.io/application-aware-quota/pkg/util"
 	aaqv1 "kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	"kubevirt.io/application-aware-quota/tests/framework"
 )
@@ -19,15 +17,4 @@ func GetAAQ(f *framework.Framework) (*aaqv1.AAQ, error) {
 		return nil, fmt.Errorf("should have only single aaq")
 	}
 	return &aaqs.Items[0], nil
-}
-
-func AaqControllerReady(clientset *kubernetes.Clientset, aaqInstallNs string) (bool, error) {
-	deployment, err := clientset.AppsV1().Deployments(aaqInstallNs).Get(context.TODO(), util.ControllerPodName, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	if *deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
-		return false, nil
-	}
-	return true, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, we are adding responsibility on the admin to choose the namespaces where pods should be mutated. Scheduling this additional configuration may be complex for admins to control and monitor. Instead, having an automated mechanism that adds a SchedulingGate where AAQ's quotas are enforced can improve the user experience by removing this responsibility from admins.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add an automated mechanism to detect namespaces where a SchedulingGate should be added
```
