### PR TITLE
Update builder image to use go v1.22

### DIFF
--- a/Dockerfile.aaq-controller
+++ b/Dockerfile.aaq-controller
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.20-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 # Install make
 RUN apk update && apk add make
@@ -18,7 +18,7 @@ WORKDIR /workdir/app
 RUN make aaq_controller
 
 # Final stage
-FROM golang:1.20-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 # Copy the binary from the builder stage to the final image
 COPY --from=builder /workdir/app/aaq_controller /app/aaq_controller

--- a/Dockerfile.aaq-operator
+++ b/Dockerfile.aaq-operator
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.20-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 
 # Install make
@@ -21,7 +21,7 @@ RUN make aaq_operator
 RUN make csv-generator
 
 # Final stage
-FROM golang:1.20-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 
 # Copy the binary from the builder stage to the final image

--- a/Dockerfile.aaq-server
+++ b/Dockerfile.aaq-server
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.20-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 # Install make
 RUN apk update && apk add make
@@ -18,7 +18,7 @@ WORKDIR /workdir/app
 RUN make aaq_server
 
 # Final stage
-FROM golang:1.20-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 # Copy the binary from the builder stage to the final image
 COPY --from=builder /workdir/app/aaq_server /app/aaq_server

--- a/example_sidecars/label-sidecar/Dockerfile.label-sidecar
+++ b/example_sidecars/label-sidecar/Dockerfile.label-sidecar
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.20-alpine as builder
+FROM docker.io/library/golang:1.22-alpine as builder
 
 # Install make
 RUN apk update && apk add make
@@ -16,7 +16,7 @@ WORKDIR /workdir/app
 RUN make label_sidecar
 
 # Final stage
-FROM golang:1.20-alpine
+FROM docker.io/library/golang:1.22-alpine
 
 # Copy the binary from the builder stage to the final image
 COPY --from=builder /workdir/app/label_sidecar /app/label_sidecar

--- a/hack/build/docker/builder/Dockerfile
+++ b/hack/build/docker/builder/Dockerfile
@@ -34,29 +34,24 @@ RUN pip3 install --upgrade j2cli operator-courier==2.1.11 && \
 	ln -s /opt/gradle/gradle-6.6/bin/gradle /usr/local/bin/gradle && \
 	rm gradle-6.6-bin.zip
 
-ENV GIMME_GO_VERSION=1.20.5 GOPATH="/go" GO111MODULE="on"
+ENV GIMME_GO_VERSION=1.22.6 GOPATH="/go" GO111MODULE="on"
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 
 RUN \
 	source /etc/profile.d/gimme.sh && \
 	eval $(go env) && \
-	go install github.com/onsi/ginkgo/ginkgo@v1.14.1 && \
-	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.12.0 && \
 	go install mvdan.cc/sh/cmd/shfmt@latest && \
 	go install github.com/mattn/goveralls@latest && \
 	go install golang.org/x/lint/golint@latest && \
     go install -v github.com/golang/protobuf/protoc-gen-go@1643683 && \
 	go install github.com/rmohr/go-swagger-utils/swagger-doc@latest && \
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3 && \
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 && \
 	go install github.com/securego/gosec/v2/cmd/gosec@latest && \
 	rm -rf "${GOPATH}/pkg"
 
-ENV BAZEL_VERSION 5.3.1
-
 COPY output-bazel-arch.sh /output-bazel-arch.sh
-
-RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-$(sh /output-bazel-arch.sh) && chmod u+x /usr/bin/bazel
 
 # Until we use a version including the fix for this Bazel issue:
 # https://github.com/bazelbuild/bazel/issues/11554


### PR DESCRIPTION
Update builder image to use go v1.22 and have controller-gen tool for future make generate logic.

Remove redundant libraries from the builder images

controller-gen tool is needed since generate-groups.sh is deprecated

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
