### PR TITLE
[tests]: Add SecurityContext to support more environments

### DIFF
--- a/tests/aaq_server_test.go
+++ b/tests/aaq_server_test.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	matav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"kubevirt.io/application-aware-quota/pkg/util"
 	aaqv1 "kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
 	"kubevirt.io/application-aware-quota/tests/builders"
@@ -64,6 +65,17 @@ var _ = Describe("AAQ Server", func() {
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceMemory: resource.MustParse("200Mi"),
+							},
+						},
+						SecurityContext: &v1.SecurityContext{
+							Privileged:               ptr.To(false),
+							AllowPrivilegeEscalation: ptr.To(false),
+							RunAsNonRoot:             ptr.To(true),
+							SeccompProfile: &v1.SeccompProfile{
+								Type: v1.SeccompProfileTypeRuntimeDefault,
+							},
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{"ALL"},
 							},
 						},
 					},

--- a/tests/e2e_plugable_policies_test.go
+++ b/tests/e2e_plugable_policies_test.go
@@ -9,6 +9,7 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	aaqclientset "kubevirt.io/application-aware-quota/pkg/generated/aaq/clientset/versioned"
 	"kubevirt.io/application-aware-quota/tests/builders"
 	"kubevirt.io/application-aware-quota/tests/framework"
@@ -113,6 +114,17 @@ func newAppsPodForQuota(name string, requests v1.ResourceList, withAppLabel bool
 					Image: "busybox",
 					Resources: v1.ResourceRequirements{
 						Requests: requests,
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged:               ptr.To(false),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
 					},
 				},
 			},

--- a/tests/utils/pod.go
+++ b/tests/utils/pod.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -328,6 +329,17 @@ func NewTestPodForQuota(name string, requests v1.ResourceList, limits v1.Resourc
 					Resources: v1.ResourceRequirements{
 						Requests: requests,
 						Limits:   limits,
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged:               ptr.To(false),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Set `Privileged`, `AllowPrivilegeEscalation`, `RunAsNonRoot`, `SeccompProfile`  and `Capabilities` in the SecurityContext to improve compatibility across environments and avoid warnings or errors related
to security policies.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
