### PR TITLE
Run operator tests for config changes and AAQ pod recreation serially

### DIFF
--- a/tests/aaq_operator_test.go
+++ b/tests/aaq_operator_test.go
@@ -39,7 +39,7 @@ const (
 	aaqServerPodPrefix     = "aaq-server-"
 )
 
-var _ = Describe("ALL Operator tests", func() {
+var _ = Describe("ALL Operator tests", Serial, func() {
 	Context("[Destructive]", func() {
 		var _ = Describe("Operator tests", func() {
 			f := framework.NewFramework("operator-test")
@@ -685,7 +685,7 @@ var _ = Describe("ALL Operator tests", func() {
 				if len(selector.MatchLabels) != 0 || len(selector.MatchExpressions) != 0 {
 					return fmt.Errorf("namespace selector should be empty. actual: %v", *mwc.Webhooks[0].NamespaceSelector)
 				}
-				
+
 				return nil
 			}).WithTimeout(90*time.Second).WithPolling(5*time.Second).ShouldNot(HaveOccurred(), "default namespace selector is not as expected")
 		})


### PR DESCRIPTION
to prevent flaky tests caused by parallel execution

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
