### PR TITLE
Filter CDI Pods

### DIFF
--- a/pkg/aaq-controller/built-in-usage-calculators/metadata-filter-calc.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/metadata-filter-calc.go
@@ -1,0 +1,65 @@
+package built_in_usage_calculators
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
+	"k8s.io/utils/clock"
+	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
+)
+
+type MetadataFilterCalculator struct {
+	Labels      map[string]string
+	Annotations map[string]string
+	MyConfigs   []v1alpha1.VmiCalcConfigName
+	CalcConfig  v1alpha1.VmiCalcConfigName
+}
+
+func NewMetadataFilterCalculator(labels, annotations map[string]string, myConfigs []v1alpha1.VmiCalcConfigName, calcConfig v1alpha1.VmiCalcConfigName) *MetadataFilterCalculator {
+	return &MetadataFilterCalculator{
+		Labels:      labels,
+		Annotations: annotations,
+		MyConfigs:   myConfigs,
+		CalcConfig:  calcConfig,
+	}
+}
+
+var cdiLabels = map[string]string{"app": "containerized-data-importer"}
+
+var cdiConfigs = []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources, v1alpha1.DedicatedVirtualResources}
+
+func NewCDIFilterCalculator(calcConfig v1alpha1.VmiCalcConfigName) *MetadataFilterCalculator {
+	return &MetadataFilterCalculator{
+		Labels:     cdiLabels,
+		MyConfigs:  cdiConfigs,
+		CalcConfig: calcConfig,
+	}
+}
+
+func (filtercalc *MetadataFilterCalculator) PodUsageFunc(pod *corev1.Pod, _ []*corev1.Pod) (corev1.ResourceList, error, bool) {
+	if !hasMatchingKeyAndValue(filtercalc.Labels, pod.Labels) &&
+		!hasMatchingKeyAndValue(filtercalc.Annotations, pod.Annotations) {
+		return corev1.ResourceList{}, nil, false
+	}
+
+	if !validConfig(filtercalc.CalcConfig, filtercalc.MyConfigs) {
+		podEvaluator := core.NewPodEvaluator(nil, clock.RealClock{})
+		rl, err := podEvaluator.Usage(pod)
+		if err != nil {
+			return corev1.ResourceList{}, err, true
+		}
+		return rl, nil, true
+	}
+
+	// got this far so filtering the Pod
+	return corev1.ResourceList{}, nil, true
+}
+
+func hasMatchingKeyAndValue(desired, actual map[string]string) bool {
+	for key, value := range desired {
+		actualValue, hasKey := actual[key]
+		if hasKey && actualValue == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/aaq-controller/built-in-usage-calculators/metadata-filter-calc_test.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/metadata-filter-calc_test.go
@@ -1,0 +1,177 @@
+package built_in_usage_calculators
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	quota "k8s.io/apiserver/pkg/quota/v1"
+	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
+)
+
+var _ = Describe("Testmetadata-filter calculator", func() {
+	matchLabel := "match"
+	matchLabelValue := "matchValue"
+	matchLabelMap := map[string]string{matchLabel: matchLabelValue}
+	matchAnno := "matchAnno"
+	matchAnnoValue := "matchAnnoValue"
+	matchAnnoMap := map[string]string{matchAnno: matchAnnoValue}
+
+	DescribeTable("Test PodUsageFunc when", func(calculator *MetadataFilterCalculator, pod *v1.Pod, expectedRl v1.ResourceList, expectMatch bool, errExpected bool) {
+		rl, err, match := calculator.PodUsageFunc(pod, nil)
+		if errExpected {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(match).To(Equal(expectMatch), "match value doesn't expected value")
+		Expect(quota.Equals(rl, expectedRl)).To(BeTrue(), "Word count wrong. Got %v, want %v", rl, expectedRl)
+	}, Entry("the pod has no annotations or labels, the pod should not match the calculator",
+		NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VirtualResources),
+		NewPodBuilder().
+			WithName("pod").
+			WithNamespace("ns").
+			Build(),
+		v1.ResourceList{},
+		false,
+		false),
+		Entry("the pod has non matching label, the pod should not match the calculator",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("nonMatch", "nonMatchValue").
+				Build(),
+			v1.ResourceList{},
+			false,
+			false),
+		Entry("the pod has non matching annotation, the pod should not match the calculator",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithAnnotations("nonMatch", "nonMatchValue").
+				Build(),
+			v1.ResourceList{},
+			false,
+			false),
+		Entry("the pod has matching label but non matching config, the pod should match the calculator and return actual usage",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VmiPodUsage),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel(matchLabel, matchLabelValue).
+				WithResourcesRequestCPU(resource.MustParse("1")).
+				WithResourcesLimitsCPU(resource.MustParse("2")).
+				WithResourcesRequestMemory(resource.MustParse("1Gi")).
+				WithResourcesLimitsMemory(resource.MustParse("2Gi")).
+				Build(),
+			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
+				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
+				v1.ResourceCPU:            resource.MustParse("1"),
+				v1.ResourceRequestsCPU:    resource.MustParse("1"),
+				v1.ResourceLimitsCPU:      resource.MustParse("2"),
+				v1.ResourceMemory:         resource.MustParse("1Gi"),
+				v1.ResourceRequestsMemory: resource.MustParse("1Gi"),
+				v1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
+			},
+			true,
+			false),
+		Entry("the pod has matching annotation but non matching config, the pod should match the calculator and return actual usage",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VmiPodUsage),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithAnnotations(matchAnno, matchAnnoValue).
+				WithResourcesRequestCPU(resource.MustParse("1")).
+				WithResourcesRequestMemory(resource.MustParse("1Gi")).
+				Build(),
+			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
+				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
+				v1.ResourceCPU:            resource.MustParse("1"),
+				v1.ResourceRequestsCPU:    resource.MustParse("1"),
+				v1.ResourceMemory:         resource.MustParse("1Gi"),
+				v1.ResourceRequestsMemory: resource.MustParse("1Gi"),
+			},
+			true,
+			false),
+		Entry("the pod has matching label and config, the pod should match the calculator and filter",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel(matchLabel, matchLabelValue).
+				Build(),
+			v1.ResourceList{},
+			true,
+			false),
+		Entry("the pod has matching annotation and config, the pod should match the calculator and filter",
+			NewMetadataFilterCalculator(matchLabelMap, matchAnnoMap, []v1alpha1.VmiCalcConfigName{v1alpha1.VirtualResources}, v1alpha1.VirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithAnnotations(matchAnno, matchAnnoValue).
+				Build(),
+			v1.ResourceList{},
+			true,
+			false),
+		Entry("CDI Filter: the pod has matching label but non matching config, the pod should match the calculator and return actual usage",
+			NewCDIFilterCalculator(v1alpha1.VmiPodUsage),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("app", "containerized-data-importer").
+				WithResourcesRequestCPU(resource.MustParse("1")).
+				WithResourcesRequestMemory(resource.MustParse("1Gi")).
+				Build(),
+			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
+				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
+				v1.ResourceCPU:            resource.MustParse("1"),
+				v1.ResourceRequestsCPU:    resource.MustParse("1"),
+				v1.ResourceMemory:         resource.MustParse("1Gi"),
+				v1.ResourceRequestsMemory: resource.MustParse("1Gi"),
+			},
+			true,
+			false),
+		Entry("CDI Filter: the pod has matching label and config (VirtualResources), the pod should match the calculator and filter",
+			NewCDIFilterCalculator(v1alpha1.VirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("app", "containerized-data-importer").
+				Build(),
+			v1.ResourceList{},
+			true,
+			false),
+		Entry("CDI Filter: the pod has matching label and config (DedicatedVirtualResources), the pod should match the calculator and filter",
+			NewCDIFilterCalculator(v1alpha1.DedicatedVirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("app", "containerized-data-importer").
+				Build(),
+			v1.ResourceList{},
+			true,
+			false),
+		Entry("CDI Filter: the pod has non matching label (key), the pod should not match the calculator",
+			NewCDIFilterCalculator(v1alpha1.DedicatedVirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("appx", "containerized-data-importer").
+				Build(),
+			v1.ResourceList{},
+			false,
+			false),
+		Entry("CDI Filter: the pod has non matching label (value), the pod should not match the calculator",
+			NewCDIFilterCalculator(v1alpha1.DedicatedVirtualResources),
+			NewPodBuilder().
+				WithName("pod").
+				WithNamespace("ns").
+				WithLabel("app", "xcontainerized-data-importer").
+				Build(),
+			v1.ResourceList{},
+			false,
+			false),
+	)
+})

--- a/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc.go
@@ -2,6 +2,7 @@ package built_in_usage_calculators
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +86,7 @@ func (launchercalc *VirtLauncherCalculator) calculateTargetUsageByConfig(pod *co
 
 func (launchercalc *VirtLauncherCalculator) CalculateUsageByConfig(pod *corev1.Pod, vmi *v15.VirtualMachineInstance, isSourceOrSingleLauncher bool) (corev1.ResourceList, error) {
 	config := launchercalc.calcConfig
-	if !validConfig(config) {
+	if !validConfig(config, MyConfigs) {
 		config = util.DefaultLauncherConfig
 	}
 	switch config {
@@ -118,8 +119,8 @@ func (launchercalc *VirtLauncherCalculator) CalculateUsageByConfig(pod *corev1.P
 	return podEvaluator.Usage(pod)
 }
 
-func validConfig(target v1alpha1.VmiCalcConfigName) bool {
-	for _, item := range MyConfigs {
+func validConfig(target v1alpha1.VmiCalcConfigName, configs []v1alpha1.VmiCalcConfigName) bool {
+	for _, item := range configs {
 		if item == target {
 			return true
 		}

--- a/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc_test.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc_test.go
@@ -1,6 +1,8 @@
 package built_in_usage_calculators
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -11,7 +13,6 @@ import (
 	v12 "kubevirt.io/api/core/v1"
 	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
 	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
-	"time"
 )
 
 var _ = Describe("Test virt-launcher calculator", func() {
@@ -376,6 +377,50 @@ func (b *PodBuilder) WithAnnotations(key, value string) *PodBuilder {
 		b.pod.Annotations = map[string]string{}
 	}
 	b.pod.Annotations[key] = value
+	return b
+}
+
+func (b *PodBuilder) WithResourcesRequestMemory(q resource.Quantity) *PodBuilder {
+	if b.pod.Spec.Containers == nil {
+		b.pod.Spec.Containers = []v1.Container{{}}
+	}
+	if b.pod.Spec.Containers[0].Resources.Requests == nil {
+		b.pod.Spec.Containers[0].Resources.Requests = v1.ResourceList{}
+	}
+	b.pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory] = q
+	return b
+}
+
+func (b *PodBuilder) WithResourcesRequestCPU(q resource.Quantity) *PodBuilder {
+	if b.pod.Spec.Containers == nil {
+		b.pod.Spec.Containers = []v1.Container{{}}
+	}
+	if b.pod.Spec.Containers[0].Resources.Requests == nil {
+		b.pod.Spec.Containers[0].Resources.Requests = v1.ResourceList{}
+	}
+	b.pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = q
+	return b
+}
+
+func (b *PodBuilder) WithResourcesLimitsMemory(q resource.Quantity) *PodBuilder {
+	if b.pod.Spec.Containers == nil {
+		b.pod.Spec.Containers = []v1.Container{{}}
+	}
+	if b.pod.Spec.Containers[0].Resources.Limits == nil {
+		b.pod.Spec.Containers[0].Resources.Limits = v1.ResourceList{}
+	}
+	b.pod.Spec.Containers[0].Resources.Limits[v1.ResourceMemory] = q
+	return b
+}
+
+func (b *PodBuilder) WithResourcesLimitsCPU(q resource.Quantity) *PodBuilder {
+	if b.pod.Spec.Containers == nil {
+		b.pod.Spec.Containers = []v1.Container{{}}
+	}
+	if b.pod.Spec.Containers[0].Resources.Limits == nil {
+		b.pod.Spec.Containers[0].Resources.Limits = v1.ResourceList{}
+	}
+	b.pod.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = q
 	return b
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CDI worker pods should be excluded from AAQ when VirtualResources or DedicatedVirtualResources configs are active.

Turns out that all CDI worker pods have `app: containerized-data-importer` annotation. So excluding them is pretty easy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://issues.redhat.com/browse/CNV-40763

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Filter out CDI worker pods when VirtualResources or DedicatedVirtualResources configs are active
```
