### PR TITLE
[Test] Fix Test Flakes by Using Patch and Built-in Namespace Labels

### DIFF
--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+const (
+	PatchReplaceOp = "replace"
+	PatchTestOp    = "test"
+	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
+)
+
+func (p *PatchOperation) MarshalJSON() ([]byte, error) {
+	switch p.Op {
+	// The 'remove' operation is the only patching operation without a value
+	// and it needs to be parsed differently.
+	case PatchRemoveOp:
+		return json.Marshal(&struct {
+			Op   string `json:"op"`
+			Path string `json:"path"`
+		}{
+			Op:   p.Op,
+			Path: p.Path,
+		})
+	case PatchTestOp, PatchReplaceOp, PatchAddOp:
+		return json.Marshal(&struct {
+			Op    string      `json:"op"`
+			Path  string      `json:"path"`
+			Value interface{} `json:"value"`
+		}{
+			Op:    p.Op,
+			Path:  p.Path,
+			Value: p.Value,
+		})
+	default:
+		return nil, fmt.Errorf("operation %s not recognized", p.Op)
+	}
+}
+
+type PatchSet struct {
+	patches []PatchOperation
+}
+
+type PatchOption func(patches *PatchSet)
+
+func New(opts ...PatchOption) *PatchSet {
+	p := &PatchSet{}
+	p.AddOption(opts...)
+	return p
+}
+
+func (p *PatchSet) GetPatches() []PatchOperation {
+	return p.patches
+}
+
+func (p *PatchSet) AddOption(opts ...PatchOption) {
+	for _, f := range opts {
+		f(p)
+	}
+}
+
+func (p *PatchSet) addOp(op, path string, value interface{}) {
+	p.patches = append(p.patches, PatchOperation{
+		Op:    op,
+		Path:  path,
+		Value: value,
+	})
+}
+
+func WithTest(path string, value interface{}) PatchOption {
+	return func(p *PatchSet) {
+		p.addOp(PatchTestOp, path, value)
+	}
+}
+
+func WithAdd(path string, value interface{}) PatchOption {
+	return func(p *PatchSet) {
+		p.addOp(PatchAddOp, path, value)
+	}
+}
+
+func WithReplace(path string, value interface{}) PatchOption {
+	return func(p *PatchSet) {
+		p.addOp(PatchReplaceOp, path, value)
+	}
+}
+
+func WithRemove(path string) PatchOption {
+	return func(p *PatchSet) {
+		p.addOp(PatchRemoveOp, path, nil)
+	}
+}
+
+func (p *PatchSet) GeneratePayload() ([]byte, error) {
+	return GeneratePatchPayload(p.patches...)
+}
+
+func (p *PatchSet) IsEmpty() bool {
+	return len(p.patches) < 1
+}
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
+}
+
+func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]byte, error) {
+	return GeneratePatchPayload(
+		PatchOperation{
+			Op:    PatchTestOp,
+			Path:  path,
+			Value: oldValue,
+		},
+		PatchOperation{
+			Op:    PatchReplaceOp,
+			Path:  path,
+			Value: newValue,
+		},
+	)
+}
+
+func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
+	var p []PatchOperation
+	err := json.Unmarshal(patch, &p)
+
+	return p, err
+}
+
+func EscapeJSONPointer(ptr string) string {
+	s := strings.ReplaceAll(ptr, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
+}

--- a/pkg/util/patch/patch_suite_test.go
+++ b/pkg/util/patch/patch_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package patch_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Patch Suite")
+}

--- a/pkg/util/patch/patch_test.go
+++ b/pkg/util/patch/patch_test.go
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package patch_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/application-aware-quota/pkg/util/patch"
+)
+
+var _ = Describe("PatchSet", func() {
+
+	It("should generate correct patch remove operation", func() {
+		Expect(patch.New(patch.WithRemove("/abcd")).GeneratePayload()).To(Equal([]byte(
+			`[{"op":"remove","path":"/abcd"}]`)))
+	})
+
+	DescribeTable("should generate correct patch add operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithAdd("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"add","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	DescribeTable("should generate correct patch replace operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithReplace("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"replace","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	DescribeTable("should generate correct patch test operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithTest("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"test","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	It("should generate correct patch with a mix of operations", func() {
+		Expect(patch.New(patch.WithRemove("/abcd"),
+			patch.WithAdd("/abcd", "test"),
+			patch.WithReplace("/abcd", "test"),
+			patch.WithTest("/abcd", "test")).GeneratePayload()).To(Equal([]byte(
+			`[{"op":"remove","path":"/abcd"},{"op":"add","path":"/abcd","value":"test"},{"op":"replace","path":"/abcd","value":"test"},{"op":"test","path":"/abcd","value":"test"}]`,
+		)))
+	})
+
+	It("should generate an empty set of patches", func() {
+		patches := patch.New()
+		Expect(patches.IsEmpty()).To(BeTrue())
+	})
+})

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/application-aware-quota/pkg/aaq-operator/resources/cluster"
@@ -154,6 +155,9 @@ func BuildTestSuite() {
 		Expect(err).ShouldNot(HaveOccurred())
 		for _, ns := range nsList.Items {
 			err := k8sClient.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{})
+			if errors.IsNotFound(err) {
+				continue
+			}
 			Expect(err).ShouldNot(HaveOccurred())
 		}
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR addresses test flakes by:Using patch instead of direct namespace updates, which can cause conflicts and lead to test failures.

In addition Reducing API calls by using Kubernetes built-in namespace labels, avoiding the need to add custom labels.

and fix afterSuite small bug in the third commit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
