### PR TITLE
[BugFix]Prevent the reconciliation process from starting on terminating namespace

### DIFF
--- a/pkg/aaq-controller/application.go
+++ b/pkg/aaq-controller/application.go
@@ -183,7 +183,7 @@ func Execute() {
 
 	app.initArqController(stop, namespaceLister)
 	app.initAaqGateController(stop, clusterQuotaLister, namespaceLister, clusterQuotaMapper)
-	app.initRQController(stop)
+	app.initRQController(stop, namespaceLister)
 
 	if app.enableClusterQuota {
 		app.clusterQuotaMappingController.GetClusterQuotaMapper().AddListener(app.aaqGateController)
@@ -282,10 +282,13 @@ func (mca *AaqControllerApp) initAaqGateController(stop <-chan struct{},
 	)
 }
 
-func (mca *AaqControllerApp) initRQController(stop <-chan struct{}) {
+func (mca *AaqControllerApp) initRQController(stop <-chan struct{},
+	namespaceLister v12.NamespaceLister,
+) {
 	mca.rqController = rq_controller.NewRQController(mca.aaqCli,
 		mca.rqInformer,
 		mca.arqInformer,
+		namespaceLister,
 		stop,
 	)
 }

--- a/pkg/aaq-controller/arq-controller/arq-controller.go
+++ b/pkg/aaq-controller/arq-controller/arq-controller.go
@@ -252,8 +252,8 @@ func (ctrl *ArqController) Execute() bool {
 
 func (ctrl *ArqController) execute(ns string) (error, enqueueState) {
 	var aaqjqc *v1alpha12.AAQJobQueueConfig
-	_, err := ctrl.namespaceLister.Get(ns)
-	if errors.IsNotFound(err) {
+	namespace, err := ctrl.namespaceLister.Get(ns)
+	if errors.IsNotFound(err) || namespace.Status.Phase == v1.NamespaceTerminating {
 		return nil, Forget
 	}
 	aaqjqcObj, exists, err := ctrl.aaqjqcInformer.GetIndexer().GetByKey(ns + "/" + arq_controller.AaqjqcName)

--- a/pkg/aaq-controller/arq-controller/arq-controller_test.go
+++ b/pkg/aaq-controller/arq-controller/arq-controller_test.go
@@ -644,6 +644,21 @@ var _ = Describe("Test arq-controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(es).To(Equal(Forget))
 		})
+
+		It("should forget the key if its namespace is terminating", func() {
+			cli := client.NewMockAAQClient(ctrl)
+			namespaceLister := testsutils.FakeNamespaceLister{
+				Namespaces: map[string]*corev1.Namespace{
+					"testNs": {
+						ObjectMeta: metav1.ObjectMeta{Name: "testNs"},
+						Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+					},
+				}}
+			qc := setupQuotaController(cli, nil, nil, namespaceLister, nil)
+			err, es := qc.execute("testNs")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(es).To(Equal(Forget))
+		})
 	})
 
 	DescribeTable("Test AddQuota when ", func(arq *v1alpha1.ApplicationAwareResourceQuota,


### PR DESCRIPTION
Prevent the reconciliation process from starting in the RQ controller and ARQ controller when the namespace is either not found or in a terminating state.
This avoids the issue where the namespace remains stuck in a terminating state, while the controller continuously enqueues the same key for that namespace.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
