### PR TITLE
types: add ARQ additional printer columns to reflect native RQ behavior

### DIFF
--- a/pkg/aaq-operator/resources/crds_generated.go
+++ b/pkg/aaq-operator/resources/crds_generated.go
@@ -4009,7 +4009,14 @@ spec:
     singular: applicationawareresourcequota
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.hard
+      name: REQUEST
+      type: string
+    - jsonPath: .status.used
+      name: LIMIT
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ApplicationAwareResourceQuota defines resources that should be

--- a/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
@@ -32,6 +32,8 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=arq;arqs,categories=all
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="REQUEST",type=string,JSONPath=`.status.hard`
+// +kubebuilder:printcolumn:name="LIMIT",type=string,JSONPath=`.status.used`
 // +k8s:openapi-gen=true
 // +genclient
 type ApplicationAwareResourceQuota struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Native resourcequotas display REQUEST and LIMIT columns showing resource caps and usage clearly. 
This PR adds similar printer columns to ARQs through CRD additionalPrinterColumns. However, since ARQs use map fields (`.status.hard` and `.status.used`), they appear as JSON maps rather than the cleaner format of native resourcequotas. Unfortunately, CRDs currently lack complex JSONPath support that could improve this formatting[1].

[1] https://github.com/kubernetes/kubernetes/pull/101205

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #133 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl get applicationawareresourcequotas.aaq.kubevirt.io now displays REQUEST and LIMIT fields similarly to native resourcequotas.
```
