### PR TITLE
builder: Enable builder image builds for s390x

### DIFF
--- a/hack/build/builder/common.sh
+++ b/hack/build/builder/common.sh
@@ -16,4 +16,4 @@
 
 DOCKER_PREFIX=${DOCKER_PREFIX:-"quay.io/kubevirt"}
 DOCKER_IMAGE=${DOCKER_IMAGE:-"kubevirt-aaq-bazel-builder"}
-ARCHITECTURES="amd64 arm64"
+ARCHITECTURES="amd64 arm64 s390x"

--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -24,7 +24,7 @@ AAQ_NAMESPACE=${AAQ_NAMESPACE:-aaq}
 CR_NAME=${CR_NAME:-aaq}
 
 # update this whenever new builder tag is created
-BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-aaq-bazel-builder:2503160819-4259ffd6}
+BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-aaq-bazel-builder:2505071036-decdddad}
 
 function parseTestOpts() {
     pkgs=""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Expand the provided builder image architectures by adding s390x.
Additionally test the newly built multiarch builder image as a follow up to #135
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
