### PR TITLE
Add readiness and liveness probes to AAQ operator

### DIFF
--- a/cmd/aaq-operator/aaq-operator.go
+++ b/cmd/aaq-operator/aaq-operator.go
@@ -9,6 +9,7 @@ import (
 	controller "kubevirt.io/application-aware-quota/pkg/aaq-operator"
 	"kubevirt.io/application-aware-quota/pkg/util"
 	"kubevirt.io/application-aware-quota/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1"
+	"net/http"
 	"os"
 	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -73,6 +74,7 @@ func main() {
 		LeaderElectionNamespace:    namespace,
 		LeaderElectionID:           "aaq-operator-leader-election-helper",
 		LeaderElectionResourceLock: "leases",
+		HealthProbeBindAddress:     ":8081",
 	}
 
 	// Create a new Manager to provide shared dependencies and start components
@@ -81,6 +83,13 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	_ = mgr.AddReadyzCheck("readyz", func(req *http.Request) error {
+		return nil
+	})
+	_ = mgr.AddHealthzCheck("healthz", func(req *http.Request) error {
+		return nil
+	})
 
 	log.Info("Registering Components.")
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/aaq-operator/resources/operator/operator.go
+++ b/pkg/aaq-operator/resources/operator/operator.go
@@ -5,6 +5,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"kubevirt.io/application-aware-quota/pkg/aaq-operator/resources"
 	utils2 "kubevirt.io/application-aware-quota/pkg/util"
 	"strings"
@@ -356,6 +357,30 @@ func createOperatorDeployment(operatorVersion, namespace, deployClusterResources
 	container.SecurityContext.Capabilities = &corev1.Capabilities{
 		Drop: []corev1.Capability{
 			"ALL",
+		},
+	}
+	container.ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Scheme: corev1.URISchemeHTTP,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8081,
+				},
+				Path: "/readyz",
+			},
+		},
+	}
+	container.LivenessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Scheme: corev1.URISchemeHTTP,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8081,
+				},
+				Path: "/healthz",
+			},
 		},
 	}
 	container.Resources = corev1.ResourceRequirements{


### PR DESCRIPTION
Ensures faster recovery and better availability

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add readiness and liveness probes to AAQ operator
```
