### PR TITLE
Allow custom resource names and add short names for VMI resource usage

### DIFF
--- a/pkg/aaq-controller/aaq-evaluator/aaq-evaluator.go
+++ b/pkg/aaq-controller/aaq-evaluator/aaq-evaluator.go
@@ -61,7 +61,7 @@ func (aaqe *AaqEvaluator) UncoveredQuotaScopes(limitedScopes []corev1.ScopedReso
 }
 
 func (aaqe *AaqEvaluator) MatchingResources(input []corev1.ResourceName) []corev1.ResourceName {
-	return aaqe.podEvaluator.MatchingResources(input)
+	return input
 }
 
 func (aaqe *AaqEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {

--- a/pkg/aaq-controller/arq-controller/arq-controller_test.go
+++ b/pkg/aaq-controller/arq-controller/arq-controller_test.go
@@ -474,7 +474,13 @@ var _ = Describe("Test arq-controller", func() {
 				},
 			},
 		},
-		Status: v1alpha1.ApplicationAwareResourceQuotaStatus{},
+		Status: v1alpha1.ApplicationAwareResourceQuotaStatus{
+			ResourceQuotaStatus: corev1.ResourceQuotaStatus{
+				Hard: corev1.ResourceList{
+					corev1.ResourceServices: resource.MustParse("1"),
+				},
+			},
+		},
 	}, corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: "quota" + rq_controller.RQSuffix, Namespace: "testing"},
 		Spec: corev1.ResourceQuotaSpec{
@@ -486,6 +492,9 @@ var _ = Describe("Test arq-controller", func() {
 			Hard: corev1.ResourceList{
 				corev1.ResourceServices: resource.MustParse("1"),
 			},
+			Used: corev1.ResourceList{
+				corev1.ResourceServices: getUsedQuantityForTest("1"),
+			},
 		},
 	},
 		v1alpha1.ApplicationAwareResourceQuotaStatus{
@@ -493,7 +502,9 @@ var _ = Describe("Test arq-controller", func() {
 				Hard: corev1.ResourceList{
 					corev1.ResourceServices: resource.MustParse("1"),
 				},
-				Used: corev1.ResourceList{},
+				Used: corev1.ResourceList{
+					corev1.ResourceServices: getUsedQuantityForTest("1"),
+				},
 			},
 		},
 		[]metav1.Object{},
@@ -526,7 +537,9 @@ var _ = Describe("Test arq-controller", func() {
 				Hard: corev1.ResourceList{
 					corev1.ResourceServices: resource.MustParse("1"),
 				},
-				Used: corev1.ResourceList{},
+				Used: corev1.ResourceList{
+					corev1.ResourceServices: getUsedQuantityForTest("0"),
+				},
 			},
 		},
 		[]metav1.Object{},
@@ -734,7 +747,7 @@ var _ = Describe("Test arq-controller", func() {
 				},
 			},
 		},
-	}, true), Entry("status, missing usage, but don't care (no informer)", &v1alpha1.ApplicationAwareResourceQuota{
+	}, true), Entry("status, should not miss Usage for costum resource", &v1alpha1.ApplicationAwareResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing"},
 		Spec: v1alpha1.ApplicationAwareResourceQuotaSpec{
 			ResourceQuotaSpec: corev1.ResourceQuotaSpec{
@@ -750,7 +763,7 @@ var _ = Describe("Test arq-controller", func() {
 				},
 			},
 		},
-	}, false), Entry("ready", &v1alpha1.ApplicationAwareResourceQuota{
+	}, true), Entry("ready", &v1alpha1.ApplicationAwareResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "testing"},
 		Spec: v1alpha1.ApplicationAwareResourceQuotaSpec{
 			ResourceQuotaSpec: corev1.ResourceQuotaSpec{

--- a/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc.go
@@ -96,20 +96,25 @@ func (launchercalc *VirtLauncherCalculator) CalculateUsageByConfig(pod *corev1.P
 		return CalculateResourceLauncherVMIUsagePodResources(vmi, isSourceOrSingleLauncher), nil
 	case v1alpha1.DedicatedVirtualResources:
 		vmiRl := corev1.ResourceList{
-			v1alpha1.ResourcePodsOfVmi: *(resource.NewQuantity(1, resource.DecimalSI)),
+			v1alpha1.ResourcePodsOfVmi:      *(resource.NewQuantity(1, resource.DecimalSI)),
+			v1alpha1.ResourcePodsOfVmiShort: *(resource.NewQuantity(1, resource.DecimalSI)),
 		}
 		usageToConvertVmiResources := CalculateResourceLauncherVMIUsagePodResources(vmi, isSourceOrSingleLauncher)
 		if memRq, ok := usageToConvertVmiResources[corev1.ResourceRequestsMemory]; ok {
 			vmiRl[v1alpha1.ResourceRequestsVmiMemory] = memRq
+			vmiRl[v1alpha1.ResourceRequestsVmiMemoryShort] = memRq
 		}
 		if memLim, ok := usageToConvertVmiResources[corev1.ResourceLimitsMemory]; ok {
 			vmiRl[v1alpha1.ResourceRequestsVmiMemory] = memLim
+			vmiRl[v1alpha1.ResourceRequestsVmiMemoryShort] = memLim
 		}
 		if cpuRq, ok := usageToConvertVmiResources[corev1.ResourceRequestsCPU]; ok {
 			vmiRl[v1alpha1.ResourceRequestsVmiCPU] = cpuRq
+			vmiRl[v1alpha1.ResourceRequestsVmiCPUShort] = cpuRq
 		}
 		if cpuLim, ok := usageToConvertVmiResources[corev1.ResourceLimitsCPU]; ok {
 			vmiRl[v1alpha1.ResourceRequestsVmiCPU] = cpuLim
+			vmiRl[v1alpha1.ResourceRequestsVmiCPUShort] = cpuLim
 		}
 		return vmiRl, nil
 	}
@@ -205,7 +210,9 @@ func CalculateResourceLauncherVMIUsagePodResources(vmi *v15.VirtualMachineInstan
 
 	requests := corev1.ResourceList{
 		corev1.ResourceRequestsMemory: memoryGuest,
+		corev1.ResourceMemory:         memoryGuest,
 		corev1.ResourceRequestsCPU:    cpuGuest,
+		corev1.ResourceCPU:            cpuGuest,
 	}
 	limits := corev1.ResourceList{
 		corev1.ResourceLimitsMemory: memoryGuest,

--- a/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc_test.go
+++ b/pkg/aaq-controller/built-in-usage-calculators/virt-launcher-usage-calc_test.go
@@ -158,8 +158,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("2Gi"),
+				v1.ResourceMemory:         resource.MustParse("2Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
 				v1.ResourceRequestsCPU:    resource.MustParse("2"),
+				v1.ResourceCPU:            resource.MustParse("2"),
 				v1.ResourceLimitsCPU:      resource.MustParse("2"),
 			},
 			true,
@@ -180,8 +182,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("2Gi"),
+				v1.ResourceMemory:         resource.MustParse("2Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
 				v1.ResourceRequestsCPU:    resource.MustParse("2"),
+				v1.ResourceCPU:            resource.MustParse("2"),
 				v1.ResourceLimitsCPU:      resource.MustParse("2"),
 			},
 			true,
@@ -204,8 +208,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("2Gi"),
+				v1.ResourceMemory:         resource.MustParse("2Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("2Gi"),
 				v1.ResourceRequestsCPU:    resource.MustParse("2"),
+				v1.ResourceCPU:            resource.MustParse("2"),
 				v1.ResourceLimitsCPU:      resource.MustParse("2"),
 			},
 			true,
@@ -230,8 +236,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("5Gi"),
+				v1.ResourceMemory:         resource.MustParse("5Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("5Gi"),
 				v1.ResourceRequestsCPU:    *(resource.NewQuantity(8, resource.BinarySI)),
+				v1.ResourceCPU:            *(resource.NewQuantity(8, resource.BinarySI)),
 				v1.ResourceLimitsCPU:      *(resource.NewQuantity(8, resource.BinarySI)),
 			},
 			true,
@@ -242,9 +250,9 @@ var _ = Describe("Test virt-launcher calculator", func() {
 				WithNamespace(fakeNs).
 				WithUID(fakeVmiUID).
 				WithNode("node1").
-				WithGuestMemory(resource.MustParse("2Gi")).                                          //desired
-				WithGuestCPUCoresSocketsThreads(1, 1, 1).                                            //desired
-				WithActualCpuDuringHotPlug(2, 2, 2).                                                 //actual
+				WithGuestMemory(resource.MustParse("2Gi")). //desired
+				WithGuestCPUCoresSocketsThreads(1, 1, 1). //desired
+				WithActualCpuDuringHotPlug(2, 2, 2). //actual
 				WithActualMemoryDuringHotPlug(resource.MustParse("5Gi"), resource.MustParse("5Gi")). //actual
 				Build()},
 			[]metav1.Object{vmimForTests},
@@ -254,8 +262,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("5Gi"),
+				v1.ResourceMemory:         resource.MustParse("5Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("5Gi"),
 				v1.ResourceRequestsCPU:    *(resource.NewQuantity(8, resource.BinarySI)),
+				v1.ResourceCPU:            *(resource.NewQuantity(8, resource.BinarySI)),
 				v1.ResourceLimitsCPU:      *(resource.NewQuantity(8, resource.BinarySI)),
 			},
 			true,
@@ -266,9 +276,9 @@ var _ = Describe("Test virt-launcher calculator", func() {
 				WithNamespace(fakeNs).
 				WithUID(fakeVmiUID).
 				WithNode("node1").
-				WithGuestMemory(resource.MustParse("5Gi")).                                          //desired
-				WithGuestCPUCoresSocketsThreads(2, 2, 2).                                            //desired
-				WithActualCpuDuringHotPlug(1, 1, 1).                                                 //actual
+				WithGuestMemory(resource.MustParse("5Gi")). //desired
+				WithGuestCPUCoresSocketsThreads(2, 2, 2). //desired
+				WithActualCpuDuringHotPlug(1, 1, 1). //actual
 				WithActualMemoryDuringHotPlug(resource.MustParse("2Gi"), resource.MustParse("2Gi")). //actual
 				Build()},
 			[]metav1.Object{vmimForTests},
@@ -278,8 +288,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(0, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(0, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("3Gi"),
+				v1.ResourceMemory:         resource.MustParse("3Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("3Gi"),
 				v1.ResourceRequestsCPU:    *(resource.NewQuantity(7, resource.BinarySI)),
+				v1.ResourceCPU:            *(resource.NewQuantity(7, resource.BinarySI)),
 				v1.ResourceLimitsCPU:      *(resource.NewQuantity(7, resource.BinarySI)),
 			},
 			true,
@@ -290,9 +302,9 @@ var _ = Describe("Test virt-launcher calculator", func() {
 				WithNamespace(fakeNs).
 				WithUID(fakeVmiUID).
 				WithNode("node1").
-				WithGuestMemory(resource.MustParse("2Gi")).                                          //desired
-				WithGuestCPUCoresSocketsThreads(1, 1, 1).                                            //desired
-				WithActualCpuDuringHotPlug(2, 2, 2).                                                 //actual
+				WithGuestMemory(resource.MustParse("2Gi")). //desired
+				WithGuestCPUCoresSocketsThreads(1, 1, 1). //desired
+				WithActualCpuDuringHotPlug(2, 2, 2). //actual
 				WithActualMemoryDuringHotPlug(resource.MustParse("5Gi"), resource.MustParse("5Gi")). //actual
 				Build()},
 			[]metav1.Object{vmimForTests},
@@ -302,8 +314,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: resource.MustParse("0"),
 				"count/pods":              resource.MustParse("0"),
 				v1.ResourceRequestsMemory: resource.MustParse("0"),
+				v1.ResourceMemory:         resource.MustParse("0"),
 				v1.ResourceLimitsMemory:   resource.MustParse("0"),
 				v1.ResourceRequestsCPU:    resource.MustParse("0"),
+				v1.ResourceCPU:            resource.MustParse("0"),
 				v1.ResourceLimitsCPU:      resource.MustParse("0"),
 			},
 			true,
@@ -315,8 +329,8 @@ var _ = Describe("Test virt-launcher calculator", func() {
 				WithUID(fakeVmiUID).
 				WithNode("node1").
 				WithGuestMemory(resource.MustParse("2Gi")). //desired
-				WithGuestCPUCoresSocketsThreads(1, 1, 1).   //desired
-				WithActualCpuDuringHotPlug(2, 2, 2).        //actual
+				WithGuestCPUCoresSocketsThreads(1, 1, 1). //desired
+				WithActualCpuDuringHotPlug(2, 2, 2). //actual
 				//the actual memory is not 5Gi but the launcher pod has already requested more memory.
 				WithActualMemoryDuringHotPlug(resource.MustParse("5Gi"), resource.MustParse("2Gi")).
 				Build()},
@@ -327,8 +341,10 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			v1.ResourceList{v1.ResourcePods: *(resource.NewQuantity(1, resource.DecimalSI)),
 				"count/pods":              *(resource.NewQuantity(1, resource.DecimalSI)),
 				v1.ResourceRequestsMemory: resource.MustParse("5Gi"),
+				v1.ResourceMemory:         resource.MustParse("5Gi"),
 				v1.ResourceLimitsMemory:   resource.MustParse("5Gi"),
 				v1.ResourceRequestsCPU:    *(resource.NewQuantity(8, resource.BinarySI)),
+				v1.ResourceCPU:            *(resource.NewQuantity(8, resource.BinarySI)),
 				v1.ResourceLimitsCPU:      *(resource.NewQuantity(8, resource.BinarySI)),
 			},
 			true,
@@ -347,8 +363,11 @@ var _ = Describe("Test virt-launcher calculator", func() {
 			[]*v1.Pod{sourcePodForTests, orphanVmiPodForTests, targetPodForTests},
 			v1alpha1.DedicatedVirtualResources,
 			v1.ResourceList{v1alpha1.ResourcePodsOfVmi: *(resource.NewQuantity(1, resource.DecimalSI)),
-				v1alpha1.ResourceRequestsVmiCPU:    *(resource.NewQuantity(8, resource.BinarySI)),
-				v1alpha1.ResourceRequestsVmiMemory: resource.MustParse("5Gi"),
+				v1alpha1.ResourcePodsOfVmiShort:         *(resource.NewQuantity(1, resource.DecimalSI)),
+				v1alpha1.ResourceRequestsVmiCPU:         *(resource.NewQuantity(8, resource.BinarySI)),
+				v1alpha1.ResourceRequestsVmiMemory:      resource.MustParse("5Gi"),
+				v1alpha1.ResourceRequestsVmiCPUShort:    *(resource.NewQuantity(8, resource.BinarySI)),
+				v1alpha1.ResourceRequestsVmiMemoryShort: resource.MustParse("5Gi"),
 			},
 			true,
 			false),

--- a/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
@@ -188,10 +188,16 @@ const (
 	//VirtualResources:
 	// ResourcePodsOfVmi Launcher Pods, number.
 	ResourcePodsOfVmi corev1.ResourceName = "requests.instances/vmi"
+	// Short form of requested Launcher Pods, number.
+	ResourcePodsOfVmiShort corev1.ResourceName = "instances/vmi"
 	// Vmi CPUs, Total Threads number(Cores*Sockets*Threads).
 	ResourceRequestsVmiCPU corev1.ResourceName = "requests.cpu/vmi"
+	// Short form of requested vCPU threads for the VMI.
+	ResourceRequestsVmiCPUShort corev1.ResourceName = "cpu/vmi"
 	// Vmi Memory Ram Size, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceRequestsVmiMemory corev1.ResourceName = "requests.memory/vmi"
+	// Short form of requested memory for the VMI, in bytes.
+	ResourceRequestsVmiMemoryShort corev1.ResourceName = "memory/vmi"
 )
 
 // AAQPriorityClass defines the priority class of the AAQ control plane.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR includes two related changes:

1. Allow custom resource names without `requests.` prefix
The AAQ evaluator used to rely on the native Kubernetes Pod evaluator, which only accepts resource names that start with `requests.` (like `requests.memory`).
The first commit removes that restriction, so AAQ can support custom resource names like `memory/vmi` or `cpu/vmi`.

2. Add short names to virt-launcher resource calculator
the second commit adds support for the following short resource names in the virt-launcher calculator:
VirtualResources Config: `memory`, `cpu`.
DedicatedVirtualResources Config: `memory/vmi`, `cpu/vmi`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Fix https://issues.redhat.com/browse/CNV-52772

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
allow custom resource names and add short names for VMI resource usage
```
