### PR TITLE
drop "all" category from AAQ CRDs to allow `kubectl get all -n<namspace`

### DIFF
--- a/pkg/aaq-operator/resources/crds_generated.go
+++ b/pkg/aaq-operator/resources/crds_generated.go
@@ -3652,8 +3652,6 @@ metadata:
 spec:
   group: aaq.kubevirt.io
   names:
-    categories:
-    - all
     kind: AAQJobQueueConfig
     listKind: AAQJobQueueConfigList
     plural: aaqjobqueueconfigs
@@ -3728,8 +3726,6 @@ metadata:
 spec:
   group: aaq.kubevirt.io
   names:
-    categories:
-    - all
     kind: ApplicationAwareAppliedClusterResourceQuota
     listKind: ApplicationAwareAppliedClusterResourceQuotaList
     plural: applicationawareappliedclusterresourcequotas
@@ -4269,8 +4265,6 @@ metadata:
 spec:
   group: aaq.kubevirt.io
   names:
-    categories:
-    - all
     kind: ApplicationAwareResourceQuota
     listKind: ApplicationAwareResourceQuotaList
     plural: applicationawareresourcequotas

--- a/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1/types.go
@@ -30,7 +30,7 @@ import (
 //
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=arq;arqs,categories=all
+// +kubebuilder:resource:shortName=arq;arqs
 // +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
 // +genclient
@@ -108,7 +108,7 @@ type AAQCertConfig struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=aaqjqc;aaqjqcs,categories=all
+// +kubebuilder:resource:shortName=aaqjqc;aaqjqcs
 // +kubebuilder:subresource:status
 type AAQJobQueueConfig struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -288,7 +288,7 @@ type ApplicationAwareClusterResourceQuotaList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=aacrq;aacrqs,categories=all
+// +kubebuilder:resource:shortName=aacrq;aacrqs
 // +k8s:openapi-gen=true
 type ApplicationAwareAppliedClusterResourceQuota struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
`applicationawareresourcequotas`, `applicationawareappliedclusterresourcequotas`, and `aaqjobqueueconfigs` are namespaced resources that currently declare `categories: [all]`.

However, built-in resources like `ResourceQuota` and `AppliedClusterResourceQuota` are not shown in `kubectl get all`, so AAQ objects should follow the same behavior.

In addition, `kubectl get all -n <namespace>` fails for non-cluster-admin users because these CRDs are not accessible to them, even though they are namespaced. This causes confusing and unnecessary permission errors.

Also, `aaqjobqueueconfigs` is an internal controller resource not meant to be exposed to users at all.

Removing the `all` category avoids these problems and aligns with the behavior of standard resources.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Fix https://issues.redhat.com/browse/CNV-66103 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
drop "all" category from AAQ CRDs to allow `kubectl get all -n<namspace>`
```
