### PR TITLE
Add flag to dump NetworkPolicies in CSV and align AAQ labels 

### DIFF
--- a/pkg/aaq-operator/resources/operator/factory.go
+++ b/pkg/aaq-operator/resources/operator/factory.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -78,4 +78,8 @@ func NewAaqCrd() *extv1.CustomResourceDefinition {
 // NewClusterServiceVersion - generates CSV for AAQ
 func NewClusterServiceVersion(data *ClusterServiceVersionData) (*csvv1.ClusterServiceVersion, error) {
 	return createClusterServiceVersion(data)
+}
+
+func NewNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
+	return createNetworkPolicyList(namespace)
 }

--- a/pkg/aaq-operator/resources/operator/operator.go
+++ b/pkg/aaq-operator/resources/operator/operator.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"github.com/coreos/go-semver/semver"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	v1 "k8s.io/api/networking/v1"
+	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"kubevirt.io/application-aware-quota/pkg/aaq-operator/resources"
@@ -352,7 +352,7 @@ func createOperatorEnvVar(operatorVersion, deployClusterResources, controllerIma
 }
 
 func createOperatorDeployment(operatorVersion, namespace, deployClusterResources, operatorImage, controllerImage, webhookServerImage, verbosity, pullPolicy string, imagePullSecrets []corev1.LocalObjectReference) *appsv1.Deployment {
-	deployment := utils2.CreateOperatorDeployment("aaq-operator", namespace, "name", "aaq-operator", utils2.OperatorServiceAccountName, imagePullSecrets, int32(1))
+	deployment := utils2.CreateOperatorDeployment("aaq-operator", namespace, utils2.AAQLabel, "aaq-operator", utils2.OperatorServiceAccountName, imagePullSecrets, int32(1))
 	container := utils2.CreateContainer("aaq-operator", operatorImage, verbosity, pullPolicy)
 	container.Ports = createPrometheusPorts()
 	container.SecurityContext.Capabilities = &corev1.Capabilities{
@@ -633,20 +633,20 @@ _The AAQ Operator does not support updates yet._
 	}, nil
 }
 
-func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
+func createNetworkPolicyList(namespace string) []*networkv1.NetworkPolicy {
 	tcp := corev1.ProtocolTCP
 
-	return []*v1.NetworkPolicy{
+	return []*networkv1.NetworkPolicy{
 		{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "networking.k8s.io/v1",
+				APIVersion: networkv1.SchemeGroupVersion.String(),
 				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aaq-allow-egress-to-api-server",
 				Namespace: namespace,
 			},
-			Spec: v1.NetworkPolicySpec{
+			Spec: networkv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -655,15 +655,15 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 						},
 					},
 				},
-				PolicyTypes: []v1.PolicyType{"Egress"},
-				Egress: []v1.NetworkPolicyEgressRule{
+				PolicyTypes: []networkv1.PolicyType{"Egress"},
+				Egress: []networkv1.NetworkPolicyEgressRule{
 					{
-						Ports: []v1.NetworkPolicyPort{
+						Ports: []networkv1.NetworkPolicyPort{
 							{
 								Protocol: &tcp,
 							},
 						},
-						To: []v1.NetworkPolicyPeer{
+						To: []networkv1.NetworkPolicyPeer{
 							{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
@@ -683,14 +683,14 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 		},
 		{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "networking.k8s.io/v1",
+				APIVersion: networkv1.SchemeGroupVersion.String(),
 				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aaq-allow-to-dns",
 				Namespace: namespace,
 			},
-			Spec: v1.NetworkPolicySpec{
+			Spec: networkv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -699,10 +699,10 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 						},
 					},
 				},
-				PolicyTypes: []v1.PolicyType{"Egress"},
-				Egress: []v1.NetworkPolicyEgressRule{
+				PolicyTypes: []networkv1.PolicyType{"Egress"},
+				Egress: []networkv1.NetworkPolicyEgressRule{
 					{
-						Ports: []v1.NetworkPolicyPort{
+						Ports: []networkv1.NetworkPolicyPort{
 							{
 								Protocol: func() *corev1.Protocol {
 									p := corev1.ProtocolTCP
@@ -716,7 +716,7 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 								}(),
 							},
 						},
-						To: []v1.NetworkPolicyPeer{
+						To: []networkv1.NetworkPolicyPeer{
 							{
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
@@ -736,23 +736,23 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 		},
 		{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "networking.k8s.io/v1",
+				APIVersion: networkv1.SchemeGroupVersion.String(),
 				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aaq-allow-ingress-to-metrics",
 				Namespace: namespace,
 			},
-			Spec: v1.NetworkPolicySpec{
+			Spec: networkv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"prometheus.aaq.kubevirt.io": "true",
 					},
 				},
-				PolicyTypes: []v1.PolicyType{"Ingress"},
-				Ingress: []v1.NetworkPolicyIngressRule{
+				PolicyTypes: []networkv1.PolicyType{"Ingress"},
+				Ingress: []networkv1.NetworkPolicyIngressRule{
 					{
-						Ports: []v1.NetworkPolicyPort{
+						Ports: []networkv1.NetworkPolicyPort{
 							{
 								Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8443},
 								Protocol: func() *corev1.Protocol { p := corev1.ProtocolTCP; return &p }(),
@@ -764,23 +764,23 @@ func createNetworkPolicyList(namespace string) []*v1.NetworkPolicy {
 		},
 		{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "networking.k8s.io/v1",
+				APIVersion: networkv1.SchemeGroupVersion.String(),
 				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aaq-allow-ingress-to-aaq-server-webhooks",
 				Namespace: namespace,
 			},
-			Spec: v1.NetworkPolicySpec{
+			Spec: networkv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"aaq.kubevirt.io": "aaq-server",
 					},
 				},
-				PolicyTypes: []v1.PolicyType{"Ingress"},
-				Ingress: []v1.NetworkPolicyIngressRule{
+				PolicyTypes: []networkv1.PolicyType{"Ingress"},
+				Ingress: []networkv1.NetworkPolicyIngressRule{
 					{
-						Ports: []v1.NetworkPolicyPort{
+						Ports: []networkv1.NetworkPolicyPort{
 							{
 								Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8443},
 								Protocol: &tcp,

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -31,10 +31,11 @@ var (
 
 	operatorVersion = flag.String("operator-version", "", "")
 
-	operatorImage   = flag.String("operator-image", "", "")
-	controllerImage = flag.String("controller-image", "", "")
-	aaqServerImage  = flag.String("aaq-server-image", "", "")
-	dumpCRDs        = flag.Bool("dump-crds", false, "optional - dumps aaq-operator related crd manifests to stdout")
+	operatorImage       = flag.String("operator-image", "", "")
+	controllerImage     = flag.String("controller-image", "", "")
+	aaqServerImage      = flag.String("aaq-server-image", "", "")
+	dumpCRDs            = flag.Bool("dump-crds", false, "optional - dumps aaq-operator related crd manifests to stdout")
+	dumpNetworkPolicies = flag.Bool("dump-network-policies", false, "optional - dumps aaq-operator related network policies to stdout")
 )
 
 func main() {
@@ -67,6 +68,15 @@ func main() {
 		cidCrd := aaqoperator.NewAaqCrd()
 		if err = util.MarshallObject(cidCrd, os.Stdout); err != nil {
 			panic(err)
+		}
+	}
+
+	if *dumpNetworkPolicies {
+		nps := aaqoperator.NewNetworkPolicyList(*namespace)
+		for _, np := range nps {
+			if err := util.MarshallObject(np, os.Stdout); err != nil {
+				panic(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Align label key for aaq-operator
Uses the same label format as other AAQ pods for better consistency and easier handling.

- Add --dump-network-policies flag to CSV generator
When this flag is used, the tool will include required OpenShift NetworkPolicy objects in the generated CSV output.


these are the policies:
```
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: aaq-allow-egress-to-api-server
spec:
  egress:
  - ports:
    - protocol: TCP
    to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-kube-apiserver
      podSelector:
        matchLabels:
          app: openshift-kube-apiserver
  podSelector:
    matchExpressions:
    - key: aaq.kubevirt.io
      operator: Exists
  policyTypes:
  - Egress
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: aaq-allow-to-dns
spec:
  egress:
  - ports:
    - protocol: TCP
    - protocol: UDP
    to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: openshift-dns
      podSelector:
        matchLabels:
          dns.operator.openshift.io/daemonset-dns: default
  podSelector:
    matchExpressions:
    - key: aaq.kubevirt.io
      operator: Exists
  policyTypes:
  - Egress
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: aaq-allow-ingress-to-metrics
spec:
  ingress:
  - ports:
    - port: 8443
      protocol: TCP
  podSelector:
    matchLabels:
      prometheus.aaq.kubevirt.io: "true"
  policyTypes:
  - Ingress
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: aaq-allow-ingress-to-aaq-server-webhooks
spec:
  ingress:
  - ports:
    - port: 8443
      protocol: TCP
  podSelector:
    matchLabels:
      aaq.kubevirt.io: aaq-server
  policyTypes:
  - Ingress
  ```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
