### PR TITLE
Revert invalid Deployment selector change

### DIFF
--- a/pkg/aaq-operator/resources/operator/operator.go
+++ b/pkg/aaq-operator/resources/operator/operator.go
@@ -352,7 +352,7 @@ func createOperatorEnvVar(operatorVersion, deployClusterResources, controllerIma
 }
 
 func createOperatorDeployment(operatorVersion, namespace, deployClusterResources, operatorImage, controllerImage, webhookServerImage, verbosity, pullPolicy string, imagePullSecrets []corev1.LocalObjectReference) *appsv1.Deployment {
-	deployment := utils2.CreateOperatorDeployment("aaq-operator", namespace, utils2.AAQLabel, "aaq-operator", utils2.OperatorServiceAccountName, imagePullSecrets, int32(1))
+	deployment := utils2.CreateOperatorDeployment("aaq-operator", namespace, "name", "aaq-operator", utils2.OperatorServiceAccountName, imagePullSecrets, int32(1))
 	container := utils2.CreateContainer("aaq-operator", operatorImage, verbosity, pullPolicy)
 	container.Ports = createPrometheusPorts()
 	container.SecurityContext.Capabilities = &corev1.Capabilities{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -160,7 +160,7 @@ func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAcco
 		},
 	}
 	deployment := ResourceBuilder.CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount, numReplicas, podSpec)
-	labels := MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{PrometheusLabelKey: PrometheusLabelValue})
+	labels := MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{PrometheusLabelKey: PrometheusLabelValue, AAQLabel: "aaq-operator"})
 	deployment.SetLabels(labels)
 	deployment.Spec.Template.SetLabels(labels)
 	return deployment


### PR DESCRIPTION
keep label alignment for AAQ pods

Reverts the selector modification introduced in
https://github.com/kubevirt/application-aware-quota/pull/159/files#diff-2da5ac067aa81ee878c8bafd2cb1b11b2e5e3549e3d56ea2dff3952c0a02bc2eR355 , which caused issues in projects like HCO
where Deployments are managed externally.
According to Kubernetes guidelines, Deployment
selectors are immutable once created and must
match pod template labels to avoid rollout failures.

This commit restores the original selector to
prevent conflicts, but keep the new label on
operator pods to ensure consistency with other
AAQ components.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
